### PR TITLE
WDPD-89 Module support email

### DIFF
--- a/Controller/Admin/ModuleSupport.php
+++ b/Controller/Admin/ModuleSupport.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\Oxid\Controller\Admin;
+
+use OxidEsales\Eshop\Application\Controller\Admin\AdminController;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Module\Module;
+
+use Wirecard\Oxid\Core\Helper;
+use Wirecard\Oxid\Extend\Core\Email;
+
+use Exception;
+
+/**
+ * Controls the view for the Module support tab in Module detail.
+ *
+ * @since 1.0.0
+ */
+class ModuleSupport extends AdminController
+{
+    /**
+     * @inheritdoc
+     *
+     * @since 1.0.0
+     */
+    protected $_sThisTemplate = 'module_support.tpl';
+
+    /**
+     * current module
+     *
+     * @var OxidEsales\Eshop\Core\Module\Module
+     *
+     * @since 1.0.0
+     */
+    protected $_oModule;
+
+    /**
+     * @inheritdoc
+     *
+     * @return string
+     *
+     * @since 1.0.0
+     */
+    public function render()
+    {
+        $sModuleId = $this->getEditObjectId();
+        $sDefaultEmail = $this->getConfig()->getActiveShop()->oxshops__oxinfoemail->value;
+
+        $this->_aViewData += [
+            'oxid' => $sModuleId,
+            'contactEmail' => $this->_getModule()->getInfo('email'),
+            'defaultEmail' => $sDefaultEmail,
+            'isOurModule' => Helper::isThisModule($sModuleId),
+        ];
+
+        if (empty($this->_aViewData['fromEmail'])) {
+            $this->_aViewData['fromEmail'] = $sDefaultEmail;
+        }
+
+        return $this->_sThisTemplate;
+    }
+
+    /**
+     * Action triggered from form to send support email
+     *
+     * @return void
+     *
+     * @since 1.0.0
+     */
+    public function sendSupportEmailAction()
+    {
+        try {
+            $this->_validateRequest();
+        } catch (Exception $e) {
+            $this->_aViewData += [
+                'alertMessage' => $e->getMessage(),
+                'alertType' => 'error',
+            ];
+            return;
+        }
+
+        $aEmailData = [];
+
+        $this->_addDataFromForm($aEmailData);
+        $this->_addShopData($aEmailData);
+
+        $this->_sendEmail($aEmailData);
+    }
+
+    /**
+     * Creates the email object and tries to send it
+     *
+     * @param array $aEmailData
+     *
+     * @since 1.0.0
+     */
+    protected function _sendEmail($aEmailData)
+    {
+        $oEmail = oxNew(Email::class);
+
+        $bEmailSent = $oEmail->sendSupportEmail($aEmailData);
+        $this->_aViewData += [
+            'alertMessage' => $bEmailSent ?
+                Helper::translate('success_email') : Helper::translate('support_send_error'),
+            'alertType' => $bEmailSent ? 'success' : 'error',
+            'replyToEmail' => '',
+            'fromEmail' => '',
+            'body' => '',
+        ];
+    }
+
+    /**
+     * Adds data received from form into the supplied array
+     *
+     * @param array $aEmailData
+     *
+     * @since 1.0.0
+     */
+    protected function _addDataFromForm(&$aEmailData)
+    {
+        $body = $this->getConfig()->getRequestParameter('module_support_text');
+        $sFromEmail = $this->getConfig()->getRequestParameter('module_support_email_from');
+        $sReplyToEmail = $this->getConfig()->getRequestParameter('module_support_email_reply');
+
+        $aEmailData = array_merge($aEmailData, [
+            'body' => $body,
+            'replyTo' => $sReplyToEmail,
+            'from' => $sFromEmail
+        ]);
+    }
+
+    /**
+     * Adds automatically provided data into the supplied array
+     *
+     * @param array $aEmailData email data array
+     *
+     * @since 1.0.0
+     */
+    protected function _addShopData(&$aEmailData)
+    {
+        $aEmailData = array_merge($aEmailData, [
+            'modules' => $this->_getOtherModules(),
+            'module' => $this->_getModule(),
+            'shopVersion' => $this->getConfig()->getVersion(),
+            'shopEdition' => $this->getConfig()->getFullEdition(),
+            'phpVersion' => phpversion(),
+            'system' => php_uname(),
+            'subject' => Helper::translate('support_email_subject'),
+            'recipient' => $this->_getModule()->getInfo('email'),
+            'payments' => Helper::getModulePaymentsIncludingInactive()
+        ]);
+    }
+
+    /**
+     * Loads the payment gateway module from database and returns it
+     *
+     * @return OxidEsales\Eshop\Core\Module\Module
+     *
+     * @since 1.0.0
+     */
+    protected function _getModule()
+    {
+        if (empty($this->_oModule)) {
+            $sModuleId = $this->getEditObjectId();
+            $this->_oModule = oxNew(Module::class);
+            if ($sModuleId) {
+                $this->_oModule->load($sModuleId);
+            }
+        }
+
+        return $this->_oModule;
+    }
+
+    /**
+     * Returns the list of other modules (without the current one)
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    protected function _getOtherModules()
+    {
+        return array_filter(Helper::getModulesList(), function ($module) {
+            return $module->getId() !== $this->_getModule()->getId();
+        });
+    }
+
+    /**
+     * Validates the current request.
+     *
+     * @throws Exception Throws exception if some request params are invalid
+     *
+     * @since 1.0.0
+     */
+    private function _validateRequest()
+    {
+        $sBody = $this->getConfig()->getRequestParameter('module_support_text');
+        $sFromEmail = $this->getConfig()->getRequestParameter('module_support_email_from');
+        $sReplyToEmail = $this->getConfig()->getRequestParameter('module_support_email_reply');
+
+        $this->_aViewData['replyToEmail'] = $sReplyToEmail;
+        $this->_aViewData['fromEmail'] = $sFromEmail;
+        $this->_aViewData['body'] = $sBody;
+
+        if (empty($sFromEmail) || !Helper::isEmailValid($sFromEmail)) {
+            throw new Exception(Helper::translate('enter_valid_email_error'));
+        }
+
+        if ($sReplyToEmail && !Helper::isEmailValid($sReplyToEmail)) {
+            throw new Exception(Helper::translate('enter_valid_email_error'));
+        }
+
+        if (empty($sBody)) {
+            throw new Exception(Helper::translate('message_empty_error'));
+        }
+    }
+}

--- a/Controller/Admin/Tab.php
+++ b/Controller/Admin/Tab.php
@@ -53,7 +53,7 @@ class Tab extends AdminDetailsController
      *
      * @since 1.0.0
      */
-    public function render(): string
+    public function render()
     {
         $this->_aViewData += [
             'data' => $this->_isListObjectIdSet() ? $this->_getData() : [],

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -61,7 +61,7 @@ class TransactionTabPostProcessing extends Tab
      *
      * @since 1.0.0
      */
-    public function render(): string
+    public function render()
     {
         $sTemplate = parent::render();
         $aRequestParameters = $this->_getRequestParameters();

--- a/Controller/Admin/TransactionList.php
+++ b/Controller/Admin/TransactionList.php
@@ -51,7 +51,7 @@ class TransactionList extends AdminListController
      *
      * @since 1.0.0
      */
-    public function render(): string
+    public function render()
     {
         $this->_aViewData += [
             'payments' => PaymentMethodHelper::getModulePayments(),

--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -255,6 +255,8 @@ class Helper
      *
      * @param string $sEmail
      * @return bool
+     *
+     * @since 1.0.0
      */
     public static function isEmailValid($sEmail)
     {

--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -10,6 +10,8 @@
 namespace Wirecard\Oxid\Core;
 
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Model\ListModel;
+use OxidEsales\Eshop\Application\Model\Payment;
 
 use Exception;
 use DateTime;
@@ -21,6 +23,8 @@ use DateTime;
  */
 class Helper
 {
+    const MODULE_ID = 'wdoxidee';
+
     /**
      * Gets the translation for a given key.
      *
@@ -50,6 +54,64 @@ class Helper
     public static function createDeviceFingerprint($sMaid, $sSessionId = null)
     {
         return $sMaid . '_' . $sSessionId;
+    }
+
+    /**
+     * Returns a list of available payments.
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public static function getPayments()
+    {
+        $oPaymentList = oxNew(ListModel::class);
+        $oPaymentList->init(Payment::class);
+
+        return $oPaymentList->getList()->getArray();
+    }
+
+    /**
+     * Returns a list of available payments added by the module.
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public static function getModulePayments()
+    {
+        return array_filter(self::getPayments(), function ($oPayment) {
+            return $oPayment->isCustomPaymentMethod();
+        });
+    }
+
+    /**
+     * Returns a list of available payments including inactive ones.
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public static function getPaymentsIncludingInactive()
+    {
+        $oPaymentList = oxNew(ListModel::class);
+        $oPaymentList->init(Payment::class);
+
+        return $oPaymentList->getListIncludingInactive()->getArray();
+    }
+
+    /**
+     * Returns a list of all payments added by the module including inactive ones.
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public static function getModulePaymentsIncludingInactive()
+    {
+        return array_filter(self::getPaymentsIncludingInactive(), function ($oPayment) {
+            return $oPayment->oxpayments__wdoxidee_isours->value;
+        });
     }
 
     /**
@@ -186,5 +248,44 @@ class Helper
     {
         $oUtilsDate = Registry::getUtilsDate();
         return $oUtilsDate->formatDBTimestamp($oUtilsDate->formTime($sTimeStamp));
+    }
+
+    /**
+     * Validates the string for e-mail address format
+     *
+     * @param string $sEmail
+     * @return bool
+     */
+    public static function isEmailValid($sEmail)
+    {
+        return !!filter_var($sEmail, FILTER_VALIDATE_EMAIL);
+    }
+
+    /**
+     * Returns list of modules
+     *
+     * @return array;
+     *
+     * @since 1.0.0
+     */
+    public static function getModulesList()
+    {
+        $sModulesDir = Registry::getConfig()->getModulesDir();
+        $oModuleList = oxNew(\OxidEsales\Eshop\Core\Module\ModuleList::class);
+        $aModules = $oModuleList->getModulesFromDir($sModulesDir);
+        return $aModules;
+    }
+
+    /**
+     * Check if $sModuleId is this plugin id
+     *
+     * @param string $sModuleId
+     * @return bool
+     *
+     * @since 1.0.0
+     */
+    public static function isThisModule($sModuleId)
+    {
+        return $sModuleId === self::MODULE_ID;
     }
 }

--- a/Extend/Core/Email.php
+++ b/Extend/Core/Email.php
@@ -21,6 +21,15 @@ use OxidEsales\Eshop\Core\Registry;
 class Email extends Email_parent
 {
     /**
+     * template for support email
+     *
+     * @var string
+     *
+     * @since 1.0.0
+     */
+    private $_sSupportEmailTemplate = 'module_support_email.tpl';
+
+    /**
      * @inheritdoc
      *
      * For custom payment method send the email in order language
@@ -105,5 +114,41 @@ class Email extends Email_parent
         }
 
         return $iReturn;
+    }
+
+    /**
+     * Send support email
+     *
+     * @param array $aEmailData Email data
+     *
+     * @return bool
+     *
+     * @since 1.0.0
+     */
+    public function sendSupportEmail($aEmailData)
+    {
+        $this->_clearMailer();
+        $oShop = $this->_getShop();
+        $oSmarty = $this->_getSmarty();
+
+        $this->setViewData('emailData', $aEmailData);
+        $this->setViewData('shopTemplateDir', $this->getConfig()->getTemplateDir(false));
+
+        $this->_processViewArray();
+
+        //set mail params (from, fromName, smtp)
+        $this->_setMailParams($oShop);
+
+        $this->setBody($oSmarty->fetch($this->_sSupportEmailTemplate));
+        $this->setSubject($aEmailData['subject']);
+
+        $this->setRecipient($aEmailData['recipient'], "");
+        $this->setFrom($aEmailData['from'], "");
+
+        $this->clearReplyTos();
+        $replyTo = !empty($aEmailData['replyTo']) ? $aEmailData['replyTo'] : $aEmailData['from'];
+        $this->setReplyTo($replyTo, "");
+
+        return $this->send();
     }
 }

--- a/Extend/ListModel.php
+++ b/Extend/ListModel.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\Oxid\Extend;
+
+/**
+ * @inheritdoc
+ *
+ * @since 1.0.0
+ */
+class ListModel extends ListModel_parent
+{
+
+    /**
+     * Function for loading the list including inactive items
+     *
+     * @return Wirecard\Oxid\Extend\ListModel
+     *
+     * @since 1.0.0
+     */
+    public function getListIncludingInactive()
+    {
+        $oListObject = $this->getBaseObject();
+        $sFieldList = $oListObject->getSelectFields();
+        $sQuery = 'select ' . $sFieldList . ' from ' . $oListObject->getViewName();
+        $this->selectString($sQuery);
+
+        return $this;
+    }
+}

--- a/Extend/Model/PaymentGateway.php
+++ b/Extend/Model/PaymentGateway.php
@@ -207,7 +207,7 @@ class PaymentGateway extends BaseModel
         $oCustomFields->add(new CustomField('shopVersion', ShopVersion::getVersion()));
 
         $oModule = oxNew(Module::class);
-        $oModule->load('wdoxidee');
+        $oModule->load(Helper::MODULE_ID);
 
         $oCustomFields->add(new CustomField('pluginName', $oModule->getTitle()));
         $oCustomFields->add(new CustomField('pluginVersion', $oModule->getInfo('version')));

--- a/Extend/ViewConfig.php
+++ b/Extend/ViewConfig.php
@@ -49,4 +49,17 @@ class ViewConfig extends ViewConfig_parent
     {
         return Helper::getInputHelpHtml($sText);
     }
+
+    /**
+     * Returns path to the module asset file
+     *
+     * @param string $sPath
+     * @return string
+     *
+     * @since 1.0.0
+     */
+    public function getPaymentGatewayUrl($sPath)
+    {
+        return $this->getModuleUrl(Helper::MODULE_ID, $sPath);
+    }
 }

--- a/Model/CreditCardPaymentMethod.php
+++ b/Model/CreditCardPaymentMethod.php
@@ -245,7 +245,8 @@ class CreditCardPaymentMethod extends PaymentMethod
     {
         return array_merge(
             parent::getPublicFieldNames(),
-            ['threeDMaid', 'nonThreeDMaxLimit', 'threeDMinLimit', 'limitsCurrency']
+            ['threeDMaid', 'nonThreeDMaxLimit', 'threeDMinLimit', 'limitsCurrency',
+            'descriptor', 'additionalInfo', 'paymentAction']
         );
     }
 }

--- a/Model/CreditCardPaymentMethod.php
+++ b/Model/CreditCardPaymentMethod.php
@@ -233,4 +233,19 @@ class CreditCardPaymentMethod extends PaymentMethod
 
         return $aOptions;
     }
+
+    /**
+     * @inheritdoc
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public function getPublicFieldNames()
+    {
+        return array_merge(
+            parent::getPublicFieldNames(),
+            ['threeDMaid', 'nonThreeDMaxLimit', 'threeDMinLimit', 'limitsCurrency']
+        );
+    }
 }

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -206,4 +206,34 @@ abstract class PaymentMethod
             ],
         ];
     }
+
+    /**
+     * Returns array of setting names which should be part of output debug infos
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public function getPublicFieldNames()
+    {
+        return ['apiUrl', 'maid', 'descriptor', 'additionalInfo', 'paymentAction'];
+    }
+
+    /**
+     * Returns an array of fields to be displayed in support email
+     *
+     * @return array
+     *
+     * @SuppressWarnings(PHPMD)
+     *
+     * @since 1.0.0
+     */
+    public function getSupportConfigFields()
+    {
+        $aFieldsPublic = array_filter($this->getConfigFields(), function ($field, $key) {
+            return in_array($key, $this->getPublicFieldNames());
+        }, ARRAY_FILTER_USE_BOTH);
+
+        return $aFieldsPublic;
+    }
 }

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -216,7 +216,7 @@ abstract class PaymentMethod
      */
     public function getPublicFieldNames()
     {
-        return ['apiUrl', 'maid', 'descriptor', 'additionalInfo', 'paymentAction'];
+        return ['apiUrl', 'maid'];
     }
 
     /**

--- a/Model/PaypalPaymentMethod.php
+++ b/Model/PaypalPaymentMethod.php
@@ -118,4 +118,16 @@ class PaypalPaymentMethod extends PaymentMethod
 
         return array_merge(parent::getConfigFields(), $aAdditionalFields);
     }
+
+    /**
+     * @inheritdoc
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public function getPublicFieldNames()
+    {
+        return array_merge(parent::getPublicFieldNames(), ['basket']);
+    }
 }

--- a/Model/PaypalPaymentMethod.php
+++ b/Model/PaypalPaymentMethod.php
@@ -128,6 +128,6 @@ class PaypalPaymentMethod extends PaymentMethod
      */
     public function getPublicFieldNames()
     {
-        return array_merge(parent::getPublicFieldNames(), ['basket']);
+        return array_merge(parent::getPublicFieldNames(), ['basket', 'descriptor', 'additionalInfo', 'paymentAction']);
     }
 }

--- a/Model/SofortPaymentMethod.php
+++ b/Model/SofortPaymentMethod.php
@@ -129,4 +129,17 @@ class SofortPaymentMethod extends PaymentMethod
 
         return array_merge(parent::getConfigFields(), $aAdditionalFields);
     }
+
+
+    /**
+     * @inheritdoc
+     *
+     * @return array
+     *
+     * @since 1.0.0
+     */
+    public function getPublicFieldNames()
+    {
+        return array_merge(parent::getPublicFieldNames(), ['additionalInfo', 'countryCode', 'logoType']);
+    }
 }

--- a/Tests/Unit/Core/HelperTest.php
+++ b/Tests/Unit/Core/HelperTest.php
@@ -12,6 +12,7 @@ use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
 
 use OxidEsales\Eshop\Application\Model\Payment;
+use OxidEsales\Eshop\Core\Module\Module;
 
 class HelperTest extends OxidEsales\TestingLibrary\UnitTestCase
 {
@@ -112,5 +113,38 @@ class HelperTest extends OxidEsales\TestingLibrary\UnitTestCase
             'zero date' => ['0000-00-00', null],
             'no date' => ['foo', null],
         ];
+    }
+
+    public function testIsEmailValid()
+    {
+        $this->assertTrue(Helper::isEmailValid('test@test.com'));
+        $this->assertFalse(Helper::isEmailValid('test'));
+        $this->assertFalse(Helper::isEmailValid(''));
+    }
+
+    public function testGetPaymentsIncludingInactive()
+    {
+        $aPaymentsList = Helper::getPaymentsIncludingInactive();
+        $this->assertNotEmpty($aPaymentsList);
+        $this->assertContainsOnly(Payment::class, $aPaymentsList);
+    }
+
+    public function testGetModulePaymentsIncludingInactive()
+    {
+        $aPaymentsList = Helper::getModulePaymentsIncludingInactive();
+        $this->assertNotEmpty($aPaymentsList);
+        $this->assertContainsOnly(Payment::class, $aPaymentsList);
+    }
+
+    public function testGetModulesList()
+    {
+        $aModuleList = Helper::getModulesList();
+        $this->assertContainsOnly(Module::class, $aModuleList);
+    }
+
+    public function testIsThisModule()
+    {
+        $this->assertTrue(Helper::isThisModule('wdoxidee'));
+        $this->assertFalse(Helper::isThisModule('test'));
     }
 }

--- a/Tests/Unit/Extend/EmailTest.php
+++ b/Tests/Unit/Extend/EmailTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ *
+ */
+
+use Wirecard\Oxid\Extend\Core\Email;
+
+class EmailTest  extends OxidEsales\TestingLibrary\UnitTestCase
+{
+    /**
+     * @dataProvider testSendSupportEmailProvider
+     */
+    public function testSendSupportEmail($aEmailData)
+    {
+        $oSmartyMock = $this->getMock("Smarty", array("fetch", "assign"));
+        $oSmartyMock->expects($this->any())->method("fetch")->will($this->returnValue(true));
+
+        $oEmail = $this->getMock(Email::class, array("_sendMail", "_getSmarty", "send"));
+        $oEmail->expects($this->any())->method("_getSmarty")->will($this->returnValue($oSmartyMock));
+
+        $oEmail->sendSupportEmail($aEmailData);
+
+        $aViewData = $oEmail->getViewData();
+        $sSubject = $oEmail->getSubject();
+        $sFrom = $oEmail->getFrom();
+        $sReplyTo = $oEmail->getReplyTo()[0][0];
+
+        $this->assertEquals($aViewData['emailData']['from'], $aEmailData['from']);
+        $this->assertEquals($sSubject, $aEmailData['subject']);
+        $this->assertEquals($sFrom, $aEmailData['from']);
+
+        if ($aEmailData['replyTo']){
+            $this->assertEquals($sReplyTo, $aEmailData['replyTo']);
+        } else {
+            $this->assertEquals($sReplyTo, $aEmailData['from']);
+        }
+
+    }
+
+    public function testSendSupportEmailProvider()
+    {
+        $aEmailDataWithoutReplyTo = [
+            'body' => 'body test',
+            'from' => 'test@from.test',
+            'modules' => [],
+            'module' => null,
+            'shopVersion' => 'test version',
+            'shopEdition' => 'test edition',
+            'phpVersion' => 'test php version',
+            'system' => 'test system',
+            'subject' => 'test subject',
+            'recipient' => 'test@recipient.test',
+            'payments' => [],
+        ];
+
+        $aEmailDataComplete = $aEmailDataWithoutReplyTo;
+        $aEmailDataComplete['replyTo'] = 'test@reply.test';
+
+        return [
+            'withoutReplyTo' => [$aEmailDataWithoutReplyTo],
+            'complete' => [$aEmailDataComplete]
+        ];
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27d41b71c8932797ea838038224b00f8",
+    "content-hash": "a33512648a5976a4cb49818e7745239b",
     "packages": [
         {
             "name": "clue/stream-filter",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-stream-filter.git",
-                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0"
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
-                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
                     "Clue\\StreamFilter\\": "src/"
                 },
                 "files": [
-                    "src/functions.php"
+                    "src/functions_include.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -56,7 +56,7 @@
                 "stream_filter_append",
                 "stream_filter_register"
             ],
-            "time": "2017-08-18T09:54:01+00:00"
+            "time": "2019-04-09T12:31:48+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1000,16 +1000,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "3896e5a7d06fd15fa4947694c8dcdd371ff147d1"
+                "reference": "fd4a5f27b7cd085b489247b9890ebca9f3e10044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/3896e5a7d06fd15fa4947694c8dcdd371ff147d1",
-                "reference": "3896e5a7d06fd15fa4947694c8dcdd371ff147d1",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/fd4a5f27b7cd085b489247b9890ebca9f3e10044",
+                "reference": "fd4a5f27b7cd085b489247b9890ebca9f3e10044",
                 "shasum": ""
             },
             "require": {
@@ -1050,7 +1050,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         },
         {
             "name": "whichbrowser/parser",
@@ -1147,16 +1147,16 @@
         },
         {
             "name": "wirecard/payment-sdk-php",
-            "version": "3.6.2",
+            "version": "3.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wirecard/paymentSDK-php.git",
-                "reference": "6664474e3ecd9e5c75be08423079c5c29245d958"
+                "reference": "670d5d775b4b9db1f3928a5471a9303713f2a0e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wirecard/paymentSDK-php/zipball/6664474e3ecd9e5c75be08423079c5c29245d958",
-                "reference": "6664474e3ecd9e5c75be08423079c5c29245d958",
+                "url": "https://api.github.com/repos/wirecard/paymentSDK-php/zipball/670d5d775b4b9db1f3928a5471a9303713f2a0e0",
+                "reference": "670d5d775b4b9db1f3928a5471a9303713f2a0e0",
                 "shasum": ""
             },
             "require": {
@@ -1164,9 +1164,9 @@
                 "monolog/monolog": ">=1.16",
                 "myclabs/php-enum": "^1.5.0",
                 "php": ">=5.6",
-                "php-http/client-common": "^1",
-                "php-http/client-implementation": "^1.0",
-                "php-http/discovery": "^1",
+                "php-http/client-common": "~1.0|~2.0",
+                "php-http/client-implementation": "~1.0",
+                "php-http/discovery": "~1.0",
                 "robrichards/xmlseclibs": "^3.0",
                 "whichbrowser/parser": "^2.0",
                 "wirecard/iso-paypal-converter": "^1.0"
@@ -1194,7 +1194,7 @@
                 "GPL-3.0-only"
             ],
             "description": "PHP SDK for the payment processing ReST API of Wirecard",
-            "time": "2019-02-21T09:34:57+00:00"
+            "time": "2019-04-23T09:05:56+00:00"
         }
     ],
     "packages-dev": [
@@ -1568,16 +1568,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7f70d79c7a24a94f8e98abb988049403a53d7b31"
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7f70d79c7a24a94f8e98abb988049403a53d7b31",
-                "reference": "7f70d79c7a24a94f8e98abb988049403a53d7b31",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0e745ead307d5dcd4e163e94a47ec04b1428943f",
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f",
                 "shasum": ""
             },
             "require": {
@@ -1627,20 +1627,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-04-01T14:03:25+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.5",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "24206aff3efe6962593297e57ef697ebb220e384"
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/24206aff3efe6962593297e57ef697ebb220e384",
-                "reference": "24206aff3efe6962593297e57ef697ebb220e384",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
                 "shasum": ""
             },
             "require": {
@@ -1699,7 +1699,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-01T07:32:59+00:00"
+            "time": "2019-04-08T14:23:48+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -1771,16 +1771,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "cdadb3765df7c89ac93628743913b92bb91f1704"
+                "reference": "2748643dd378626c4d348a31ad12394e2d6f7ea8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cdadb3765df7c89ac93628743913b92bb91f1704",
-                "reference": "cdadb3765df7c89ac93628743913b92bb91f1704",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2748643dd378626c4d348a31ad12394e2d6f7ea8",
+                "reference": "2748643dd378626c4d348a31ad12394e2d6f7ea8",
                 "shasum": ""
             },
             "require": {
@@ -1840,11 +1840,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-04-16T11:19:53+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1937,7 +1937,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2011,16 +2011,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.2.5",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1e6cbb41dadcaf29e0db034d6ad0d039a9df06e6"
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1e6cbb41dadcaf29e0db034d6ad0d039a9df06e6",
-                "reference": "1e6cbb41dadcaf29e0db034d6ad0d039a9df06e6",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8cf39fb4ccff793340c258ee7760fd40bfe745fe",
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe",
                 "shasum": ""
             },
             "require": {
@@ -2056,7 +2056,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-10T20:07:02+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         }
     ],
     "aliases": [],

--- a/menu.xml
+++ b/menu.xml
@@ -15,6 +15,11 @@
         <TAB id="transaction_details_title" pg_translate="1" cl="wcpg_order_transaction_details"/>
       </SUBMENU>
     </MAINMENU>
+    <MAINMENU id="mxextensions">
+      <SUBMENU id="mxmodule" cl="module" list="module_list">
+          <TAB id="text_support" cl="wcpg_module_support" pg_translate="1"/>
+      </SUBMENU>
+    </MAINMENU>
   </OXMENU>
   <OXMENU id="heading_title" pg_translate="1">
     <MAINMENU id="heading_title_transaction_details" pg_translate="1">

--- a/metadata.php
+++ b/metadata.php
@@ -68,7 +68,9 @@ $aModule = array(
         \OxidEsales\Eshop\Application\Controller\ThankYouController::class
             => \Wirecard\Oxid\Extend\Controller\ThankYouController::class,
         \OxidEsales\Eshop\Core\Email::class
-            => \Wirecard\Oxid\Extend\Core\Email::class
+            => \Wirecard\Oxid\Extend\Core\Email::class,
+        \OxidEsales\Eshop\Core\Model\ListModel::class
+            => \Wirecard\Oxid\Extend\ListModel::class,
     ),
     'controllers'       => array(
         'wcpg_transaction'
@@ -92,6 +94,8 @@ $aModule = array(
         'wcpg_notifyhandler'
             => \Wirecard\Oxid\Controller\NotifyHandler::class,
         'wcpg_form_interaction' => \Wirecard\Oxid\Controller\FormInteractionController::class,
+        'wcpg_module_support'
+            => \Wirecard\Oxid\Controller\Admin\ModuleSupport::class,
     ),
     'blocks'            => array(
         array(
@@ -174,6 +178,11 @@ $aModule = array(
             'block' => 'email_plain_order_owner_orderemail',
             'file' => 'views/blocks/email_plain_order_owner_orderemail.tpl'
         ),
+        array(
+            'template' => 'module_config.tpl',
+            'block' => 'admin_module_config_form',
+            'file' => 'views/admin/blocks/admin_module_config_form.tpl'
+        ),
     ),
     'templates'         => array(
         'transaction.tpl'                   => 'wirecard/paymentgateway/views/admin/tpl/transaction.tpl',
@@ -182,6 +191,8 @@ $aModule = array(
         'tab_table.tpl'                     => 'wirecard/paymentgateway/views/admin/tpl/tab_table.tpl',
         'tab_post_processing.tpl'           => 'wirecard/paymentgateway/views/admin/tpl/tab_post_processing.tpl',
         'form_interaction.tpl'              => 'wirecard/paymentgateway/views/form_interaction.tpl',
+        'module_support.tpl'                => 'wirecard/paymentgateway/views/admin/tpl/module_support.tpl',
+        'module_support_email.tpl'          => 'wirecard/paymentgateway/views/admin/tpl/email/module_support_email.tpl',
     ),
     'events'            => array(
         'onActivate'        => '\Wirecard\Oxid\Core\OxidEEEvents::onActivate',

--- a/metadata.php
+++ b/metadata.php
@@ -7,6 +7,8 @@
  * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
  */
 
+use Wirecard\Oxid\Core\Helper;
+
 /**
  * Metadata version
  */
@@ -34,7 +36,7 @@ $aModuleDescriptions = array(
  * Module information
  */
 $aModule = array(
-    'id'                => 'wdoxidee',
+    'id'                => Helper::MODULE_ID,
     'title'             => 'Wirecard OXID Module',
     'description'       => array(
         'de' => $aModuleDescriptions['de'],

--- a/views/admin/tpl/email/module_support_email.tpl
+++ b/views/admin/tpl/email/module_support_email.tpl
@@ -1,0 +1,181 @@
+[{assign var="shop"      value=$oEmailView->getShop()}]
+[{assign var="oViewConf" value=$oEmailView->getViewConfig()}]
+[{assign var="userinfo"  value=$oEmailView->getUser()}]
+[{assign var="headerTemplate" value="`$shopTemplateDir`email/html/header.tpl"}]
+
+[{include file=$headerTemplate title=$emailData.subject}]
+
+<table border="0" width="100%" cellspacing="10" cellpadding="2" bgcolor="#FFFFFF" class="column">
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_from"}]</b>
+    </td>
+    <td style="white-space:nowrap;">[{$shop->oxshops__oxname->getRawValue()|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="EMAIL"}]</b>
+    </td>
+    <td style="white-space:nowrap;">[{$emailData.from|oxescape}]</td>
+  </tr>
+  [{if $emailData.replyTo }]
+    <tr>
+      <td class="text-pad" style="white-space:nowrap;">
+        <b>[{oxmultilang ident="support_email_reply_to"}]</b>
+      </td>
+      <td style="white-space:nowrap;">[{$emailData.replyTo|oxescape}]</td>
+    </tr>
+  [{/if}]
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="text_message"}]</b>
+    </td>
+    <td>[{$emailData.body|oxescape|nl2br}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" colspan="2">&nbsp;</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_shop_version"}]</b>
+    </td>
+    <td>[{$emailData.shopVersion|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_shop_edition"}]</b>
+    </td>
+    <td>[{$emailData.shopEdition|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_module_title"}]</b>
+    </td>
+    <td>[{$emailData.module->getTitle()|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_module_version"}]</b>
+    </td>
+    <td>[{$emailData.module->getInfo('version')|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_php"}]</b>
+    </td>
+    <td>[{$emailData.phpVersion|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" style="white-space:nowrap;">
+      <b>[{oxmultilang ident="support_email_system"}]</b>
+    </td>
+    <td>[{$emailData.system|oxescape}]</td>
+  </tr>
+  <tr>
+    <td class="text-pad" colspan="2">&nbsp;</td>
+  </tr>
+  <tr>
+    <td class="text-pad" colspan="2">
+      <b style="white-space:nowrap;">[{oxmultilang ident="support_email_modules"}]</b>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <table>
+        <tr>
+          <th class="text-pad">
+            [{oxmultilang ident="support_email_module_id"}]
+          </th>
+          <th class="text-pad">
+            [{oxmultilang ident="support_email_module_title"}]
+          </th>
+          <th class="text-pad">
+            [{oxmultilang ident="support_email_module_version"}]
+          </th>
+          <th class="text-pad">
+            [{oxmultilang ident="GENERAL_ACTIVE"}]
+          </th>
+        </tr>
+        [{foreach from=$emailData.modules item=module}]
+          <tr>
+            <td class="text-pad" style="white-space:nowrap;">
+              [{$module->getId()}]
+            </td>
+            <td class="text-pad">
+              [{$module->getTitle()}]
+            </td>
+            <td class="text-pad">
+              [{$module->getInfo('version')}]
+            </td>
+            <td class="text-pad" style="white-space:nowrap;">
+              [{if $module->isActive()}]
+                [{oxmultilang ident="yes"}]
+              [{/if}]
+            </td>
+          </tr>
+        [{/foreach}]
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td class="text-pad" colspan="2">&nbsp;</td>
+  </tr>
+  <tr>
+    <td class="text-pad" colspan="2">
+      <b style="white-space:nowrap;">[{oxmultilang ident="payment_method_settings"}]</b>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <table>
+        [{* List all payments *}]
+        [{foreach from=$emailData.payments item=payment}]
+          [{assign var="paymentMethod" value=$payment->getPaymentMethod()}]
+          <tr>
+            <th class="text-pad" style="white-space:nowrap;" colspan="2">
+              [{$payment->oxpayments__oxdesc->value}]
+            </th>
+          </tr>
+          <tr>
+            <td class="text-pad" style="white-space:nowrap;">
+              [{oxmultilang ident="GENERAL_ACTIVE"}]
+            </td>
+            <td class="text-pad">
+              [{if $payment->oxpayments__oxactive->value}]
+                [{oxmultilang ident="yes"}]
+              [{else}]
+                [{oxmultilang ident="no"}]
+              [{/if}]
+            </td>
+          </tr>
+          [{* List all support fields of payment *}]
+          [{foreach from=$paymentMethod->getSupportConfigFields() item=configField}]
+            [{assign var="fieldName" value=$configField.field}]
+            <tr>
+              <td class="text-pad" style="white-space:nowrap;">
+                [{$configField.title}]
+              </td>
+              <td class="text-pad">
+                [{if $configField.type == 'text' }]
+                  [{$payment->$fieldName->value}]
+                [{/if}]
+                [{if $configField.type == 'select'}]
+                  [{foreach from=$configField.options key=optionKey item=optionValue}]
+                    [{if $payment->$fieldName->value == $optionKey}]
+                      [{$optionValue}]
+                    [{/if}]
+                  [{/foreach}]
+                [{/if}]
+              </td>
+            </tr>
+          [{/foreach}]
+          <tr>
+            <td class="text-pad" colspan="2">&nbsp;</td>
+          </tr>
+        [{/foreach}]
+      </table>
+    </td>
+  </tr>
+</table>
+
+</td></tr></table></center></td></tr></table></body></html>

--- a/views/admin/tpl/module_support.tpl
+++ b/views/admin/tpl/module_support.tpl
@@ -1,0 +1,65 @@
+[{include file="headitem.tpl" title="GENERAL_ADMIN_TITLE"|oxmultilangassign}]
+
+<form name="transfer" id="transfer" action="[{$oViewConf->getSelfLink()}]" method="post">
+  [{$oViewConf->getHiddenSid()}]
+  <input type="hidden" name="oxid" value="[{$oxid}]">
+  <input type="hidden" name="cl" value="wcpg_module_support">
+</form>
+
+[{if $isOurModule && $contactEmail}]
+  [{if $alertMessage}]
+  <tr>
+    <td colspan="2">
+      <div class="messagebox">
+        <div [{if $alertType === 'error'}]class="warning"[{/if}] [{if $alertType === 'success'}]class="success"[{/if}]>[{$alertMessage}]</div>
+      </div>
+    </td>
+  </tr>
+  [{/if}]
+
+  <form action="[{$oViewConf->getSelfLink()}]" method="post">
+    <input type="hidden" name="oxid" value="[{$oxid}]">
+    <input type="hidden" name="cl" value="wcpg_module_support">
+    <input type="hidden" name="fnc" value="sendSupportEmailAction">
+
+    <h3>[{oxmultilang ident="heading_title_support"}]</h3>
+
+    <p>[{oxmultilang ident="support_description"}]: <strong>[{$contactEmail}]</strong></p>
+    <br>
+    <table cellspacing="0" cellpadding="0" border="0" width="98%">
+      <tbody>
+      <tr>
+        <td class="edittext" width="70">
+          [{oxmultilang ident="config_email"}]
+        </td>
+        <td class="edittext">
+          <input type="text" name="module_support_email_from" class="editinput" value="[{$fromEmail}]" placeholder="[{$defaultEmail}]" size="40"/>
+        </td>
+      </tr>
+      <tr>
+        <td class="edittext" width="70">
+          [{oxmultilang ident="config_reply_to"}]
+        </td>
+        <td class="edittext">
+          <input type="text" name="module_support_email_reply" class="editinput" value="[{$replyToEmail}]" placeholder="[{$defaultEmail}]" size="40"/>
+        </td>
+      </tr>
+      <tr>
+        <td class="edittext" width="70">
+          [{oxmultilang ident="config_message"}]
+        </td>
+        <td class="edittext">
+          <textarea name="module_support_text" class="editinput" rows="6" cols="40">[{$body}]</textarea>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <input type="submit" value="[{oxmultilang ident="send_email"}]" />
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </form>
+[{/if}]
+
+[{include file="bottomitem.tpl"}]

--- a/views/blocks/wirecard_credit_card_fields.tpl
+++ b/views/blocks/wirecard_credit_card_fields.tpl
@@ -11,7 +11,7 @@
 
   [{oxscript include="js/libs/jquery.min.js" priority=8}]
   [{oxscript include="https://api-test.wirecard.com/engine/hpp/paymentPageLoader.js" priority=8}]
-  [{oxscript include=$oViewConf->getModuleUrl('wdoxidee','out/js/credit_card_form.js') priority=9}]
+  [{oxscript include=$oViewConf->getPaymentGatewayUrl('out/js/credit_card_form.js') priority=9}]
   [{oxscript add=$oView->getInitCreditCardFormJavaScript() priority=10}]
 
   <div id="wirecard-cc-error"></div>


### PR DESCRIPTION
### This PR

* Adds new "Module support" tab on the Extensions/Module detail page

### Notes

* Metadata.php email value is used as recipient of the support email
* Email from and reply to values have defaults from Oxid Master settings -> Core settings -> Info e-mail Address, but can be changed by user

### How to Test

* Login to the admin
* Go to Extensions → Modules and activate _Wirecard Oxid EE Paymentgateway_
* Go to tab _Support_
* Enter the message and send the email

### Jira Links

* Jira Ticket [WDPD-89](https://jira.parkside.at/browse/WDPD-89)
* It is the subtask of [WDPD-55](https://jira.parkside.at/browse/WDPD-55)
