### PR TITLE
WDPD 90: Config Order Delete on Fail/Cancel

### DIFF
--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -141,5 +141,9 @@ class NotifyHandler extends FrontendController
             $sDescription = $oStatus->getDescription();
             $this->_oLogger->error("\t$sSeverity with code $sCode and message '$sDescription' occurred.");
         }
+
+        $oOrder = oxNew(Order::class);
+        $oOrder->loadWithTransactionId($oResponse->getParentTransactionId());
+        $oOrder->handleOrderState(Order::STATE_FAILED);
     }
 }

--- a/Core/OrderHelper.php
+++ b/Core/OrderHelper.php
@@ -194,7 +194,7 @@ class OrderHelper
         Registry::getSession()->setVariable(self::PAY_ERROR_TEXT_VARIABLE, join('<br/>', $aErrorDescriptions));
         $sRedirectUrl = Registry::getConfig()->getShopHomeUrl() . 'cl=payment';
 
-        $oOrder->delete();
+        $oOrder->handleOrderState(Order::STATE_FAILED);
 
         Registry::getUtils()->redirect($sRedirectUrl);
     }

--- a/Core/OxidEEEvents.php
+++ b/Core/OxidEEEvents.php
@@ -177,6 +177,14 @@ class OxidEEEvents
             " ADD COLUMN `WDOXIDEE_ADDITIONAL_INFO` tinyint(1) default 0 NOT NULL";
         self::_addColumnIfNotExists(self::PAYMENT_TABLE, 'WDOXIDEE_ADDITIONAL_INFO', $sQueryAddInfo);
 
+        $sQueryAddDelCanceled = "ALTER TABLE " . self::PAYMENT_TABLE .
+            " ADD COLUMN `WDOXIDEE_DELETE_CANCELED_ORDER` tinyint(1) default 0 NOT NULL";
+        self::_addColumnIfNotExists(self::PAYMENT_TABLE, 'WDOXIDEE_DELETE_CANCELED_ORDER', $sQueryAddDelCanceled);
+
+        $sQueryAddDelFailed = "ALTER TABLE " . self::PAYMENT_TABLE .
+            " ADD COLUMN `WDOXIDEE_DELETE_FAILED_ORDER` tinyint(1) default 0 NOT NULL";
+        self::_addColumnIfNotExists(self::PAYMENT_TABLE, 'WDOXIDEE_DELETE_FAILED_ORDER', $sQueryAddDelFailed);
+
         $sQueryAddCountryCode = "ALTER TABLE " . self::PAYMENT_TABLE .
             " ADD COLUMN `WDOXIDEE_COUNTRYCODE` varchar(5) default '' NOT NULL";
         self::_addColumnIfNotExists(self::PAYMENT_TABLE, 'WDOXIDEE_COUNTRYCODE', $sQueryAddCountryCode);

--- a/Extend/Controller/OrderController.php
+++ b/Extend/Controller/OrderController.php
@@ -260,6 +260,8 @@ class OrderController extends OrderController_parent
             $oResponse = $oPaymentGateway->executeTransaction($oTransaction, $oOrder, $oBasket);
         } catch (\Exception $exc) {
             $oLogger->error(__METHOD__ . ": Error processing transaction: " . $exc->getMessage(), [$exc]);
+            $oOrder->handleOrderState(Order::STATE_FAILED);
+
             return $this->_getNextStep(Order::ORDER_STATE_PAYMENTERROR);
         }
 

--- a/Extend/Controller/PaymentController.php
+++ b/Extend/Controller/PaymentController.php
@@ -6,9 +6,11 @@
  * - License can be found under:
  * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
  */
+
 namespace Wirecard\Oxid\Extend\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
+
 use Wirecard\Oxid\Extend\Model\Order;
 
 /**

--- a/Extend/Controller/PaymentController.php
+++ b/Extend/Controller/PaymentController.php
@@ -12,9 +12,11 @@ use OxidEsales\Eshop\Core\Registry;
 use Wirecard\Oxid\Extend\Model\Order;
 
 /**
- * Class Order
+ * Class PaymentController
  *
  * @mixin \OxidEsales\Eshop\Application\Controller\PaymentController
+ *
+ * @since 1.0.0
  */
 class PaymentController extends PaymentController_parent
 {
@@ -23,6 +25,8 @@ class PaymentController extends PaymentController_parent
 
     /**
      * @inheritdoc
+     *
+     * @since 1.0.0
      */
     protected function _unsetPaymentErrors()
     {

--- a/Extend/Controller/PaymentController.php
+++ b/Extend/Controller/PaymentController.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+namespace Wirecard\Oxid\Extend\Controller;
+
+use OxidEsales\Eshop\Core\Registry;
+use Wirecard\Oxid\Extend\Model\Order;
+
+/**
+ * Class Order
+ *
+ * @mixin \OxidEsales\Eshop\Application\Controller\PaymentController
+ */
+class PaymentController extends PaymentController_parent
+{
+    const ERROR_CODE_CANCELED = '-100';
+    const ERROR_CODE_FAILED = '-101';
+
+    /**
+     * @inheritdoc
+     */
+    protected function _unsetPaymentErrors()
+    {
+        $oOrder = oxNew(Order::class);
+        $sOrderId = Registry::getSession()->getVariable('sess_challenge');
+
+        if ($oOrder->load($sOrderId)) {
+            switch (Registry::getConfig()->getRequestParameter('payerror')) {
+                case self::ERROR_CODE_CANCELED:
+                    $oOrder->handleOrderState(Order::STATE_CANCELED);
+                    break;
+                case self::ERROR_CODE_FAILED:
+                    $oOrder->handleOrderState(Order::STATE_FAILED);
+                    break;
+            }
+        }
+
+        parent::_unsetPaymentErrors();
+    }
+}

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -446,6 +446,7 @@ class Order extends Order_parent
      * Handles the order after a certain order state is set.
      *
      * @param string $sState
+     * @return void
      *
      * @since 1.0.0
      */
@@ -456,11 +457,13 @@ class Order extends Order_parent
                 $this->_oLogger->info(
                     "Order `{$this->getId()}` was deleted as requested by the payment method config."
                 );
-            } else {
-                $this->_oLogger->error(
-                    "Order `{$this->getId()}` could not be deleted as requested by the payment method config."
-                );
+
+                return;
             }
+
+            $this->_oLogger->error(
+                "Order `{$this->getId()}` could not be deleted as requested by the payment method config."
+            );
         }
     }
 

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -44,11 +44,15 @@ class Order extends Order_parent
 
     /**
      * @var LoggerInterface
+     *
+     * @since 1.0.0
      */
     protected $oLogger;
 
     /**
      * @inheritdoc
+     *
+     * @since 1.0.0
      */
     public function __construct()
     {
@@ -442,6 +446,8 @@ class Order extends Order_parent
      * Handles the order after a certain order state is set.
      *
      * @param string $sState
+     *
+     * @since 1.0.0
      */
     public function handleOrderState($sState)
     {
@@ -463,6 +469,8 @@ class Order extends Order_parent
      *
      * @param string $sState
      * @return bool
+     *
+     * @since 1.0.0
      */
     private function _shouldBeDeletedOnState($sState)
     {

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -24,6 +24,8 @@ use Wirecard\Oxid\Core\AccountHolderHelper;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
 use Wirecard\Oxid\Extend\Core\Email;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Class Order
  *
@@ -38,6 +40,22 @@ class Order extends Order_parent
     const STATE_PROCESSING = 'processing';
     const STATE_CANCELED = 'canceled';
     const STATE_REFUNDED = 'refunded';
+    const STATE_FAILED = 'failed';
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $oLogger;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->oLogger = Registry::getLogger();
+    }
 
     /**
      * Loads order data from DB.
@@ -206,6 +224,7 @@ class Order extends Order_parent
             self::STATE_PROCESSING => Helper::translate('order_status_purchased'),
             self::STATE_CANCELED => Helper::translate('order_status_cancelled'),
             self::STATE_REFUNDED => Helper::translate('order_status_refunded'),
+            self::STATE_FAILED => Helper::translate('order_status_failed'),
         ];
     }
 
@@ -406,7 +425,7 @@ class Order extends Order_parent
 
         // Dont send pending emails if not enabled in module settings
         if ($this->isPaymentPending() && !$bSendPendingEmails) {
-            Registry::getLogger()->debug('Prevent sending pending order by email with id: '. $this->getId());
+            $this->logger->debug('Prevent sending pending order by email with id: '. $this->getId());
             return true;
         }
 
@@ -417,5 +436,39 @@ class Order extends Order_parent
         $oEmail->sendOrderEmailToOwner($this);
 
         return $bRet;
+    }
+
+    /**
+     * Handles the order after a certain order state is set.
+     *
+     * @param string $sState
+     */
+    public function handleOrderState($sState)
+    {
+        if ($this->_shouldBeDeletedOnState($sState)) {
+            if ($this->delete()) {
+                $this->oLogger->info(
+                    "Order `{$this->getId()}` was deleted as requested by the payment method config."
+                );
+            } else {
+                $this->oLogger->error(
+                    "Order {$this->getId()} could not be deleted as requested by the payment method config."
+                );
+            }
+        }
+    }
+
+    /**
+     * Checks if the order should be deleted if a certain order state is set.
+     *
+     * @param string $sState
+     * @return bool
+     */
+    private function _shouldBeDeletedOnState($sState)
+    {
+        $oPayment = $this->getOrderPayment();
+
+        return ($sState === self::STATE_CANCELED && $oPayment->oxpayments__wdoxidee_delete_canceled_order->value) ||
+            ($sState === self::STATE_FAILED && $oPayment->oxpayments__wdoxidee_delete_failed_order->value);
     }
 }

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -47,7 +47,7 @@ class Order extends Order_parent
      *
      * @since 1.0.0
      */
-    protected $oLogger;
+    protected $_oLogger;
 
     /**
      * @inheritdoc
@@ -58,7 +58,7 @@ class Order extends Order_parent
     {
         parent::__construct();
 
-        $this->oLogger = Registry::getLogger();
+        $this->_oLogger = Registry::getLogger();
     }
 
     /**
@@ -453,11 +453,11 @@ class Order extends Order_parent
     {
         if ($this->_shouldBeDeletedOnState($sState)) {
             if ($this->delete()) {
-                $this->oLogger->info(
+                $this->_oLogger->info(
                     "Order `{$this->getId()}` was deleted as requested by the payment method config."
                 );
             } else {
-                $this->oLogger->error(
+                $this->_oLogger->error(
                     "Order `{$this->getId()}` could not be deleted as requested by the payment method config."
                 );
             }

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -458,7 +458,7 @@ class Order extends Order_parent
                 );
             } else {
                 $this->oLogger->error(
-                    "Order {$this->getId()} could not be deleted as requested by the payment method config."
+                    "Order `{$this->getId()}` could not be deleted as requested by the payment method config."
                 );
             }
         }

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -167,10 +167,10 @@ abstract class PaymentMethod
                 'title' => Helper::translate('config_http_password'),
             ],
             'testCredentials' => [
-                'type'        => 'button',
-                'onclick'     => 'wdTestPaymentMethodCredentials()',
-                'text'        => Helper::translate('test_credentials'),
-                'colspan'     => '2',
+                'type' => 'button',
+                'onclick' => 'wdTestPaymentMethodCredentials()',
+                'text' => Helper::translate('test_credentials'),
+                'colspan' => '2',
             ],
             'maid' => [
                 'type' => 'text',
@@ -183,6 +183,26 @@ abstract class PaymentMethod
                 'field' => 'oxpayments__wdoxidee_secret',
                 'title' => Helper::translate('config_merchant_secret'),
                 'description' => Helper::translate('config_three_d_merchant_secret_desc'),
+            ],
+            'deleteCanceledOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_canceled_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_cancel_order'),
+                'description' => Helper::translate('config_delete_cancel_order_desc'),
+            ],
+            'deleteFailedOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_failed_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_failure_order'),
+                'description' => Helper::translate('config_delete_failure_order_desc'),
             ],
         ];
     }

--- a/Tests/Integration/Model/OrderTest.php
+++ b/Tests/Integration/Model/OrderTest.php
@@ -47,6 +47,20 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
                     ['2', '2', null],
                 ],
             ],
+            [
+               'table' => 'oxpayments',
+               'columns' => [
+                   'oxid',
+                   'wdoxidee_isours',
+                   'wdoxidee_delete_canceled_order',
+                   'wdoxidee_delete_failed_order',
+               ],
+               'rows' => [
+                   ['oxidinvoice', false, false, false],
+                   ['wdpaypal', true, true, false],
+                   ['wdcreditcard', true, true, true],
+               ],
+           ]
         ];
     }
 
@@ -88,12 +102,12 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
     /**
      * @dataProvider testIsCustomPaymentMethodProvider
      */
-    public function testIsCustomPaymentMethod($input, $expected)
+    public function testIsCustomPaymentMethod($orderId, $isCustomPaymentMethod)
     {
         $oOrder = oxNew(Order::class);
-        $oOrder->load($input);
+        $oOrder->load($orderId);
 
-        $this->assertEquals($oOrder->isCustomPaymentMethod(), $expected);
+        $this->assertEquals($oOrder->isCustomPaymentMethod(), $isCustomPaymentMethod);
     }
 
     public function testIsCustomPaymentMethodProvider()
@@ -107,12 +121,12 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
     /**
      * @dataProvider testIsPaymentPendingProvider
      */
-    public function testIsPaymentPending($input, $expected)
+    public function testIsPaymentPending($orderId, $isPaymentPending)
     {
         $oOrder = oxNew(Order::class);
-        $oOrder->load($input);
+        $oOrder->load($orderId);
 
-        $this->assertEquals($oOrder->isPaymentPending(), $expected);
+        $this->assertEquals($oOrder->isPaymentPending(), $isPaymentPending);
     }
 
     public function testIsPaymentPendingProvider()
@@ -126,12 +140,12 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
     /**
      * @dataProvider testIsPaymentSuccessProvider
      */
-    public function testIsPaymentSuccess($input, $expected)
+    public function testIsPaymentSuccess($orderId, $isPaymentSuccess)
     {
         $oOrder = oxNew(Order::class);
-        $oOrder->load($input);
+        $oOrder->load($orderId);
 
-        $this->assertEquals($oOrder->isPaymentSuccess(), $expected);
+        $this->assertEquals($oOrder->isPaymentSuccess(), $isPaymentSuccess);
     }
 
     public function testIsPaymentSuccessProvider()
@@ -155,5 +169,27 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
         $oOrder = oxNew(Order::class);
 
         $this->assertInstanceOf(AccountHolder::class, $oOrder->getShippingAccountHolder());
+    }
+
+    /**
+     * @dataProvider testHandleOrderStateProvider
+     */
+    public function testHandleOrderState($orderId, $state, $shouldBeDeleted)
+    {
+        $oOrder = oxNew(Order::class);
+        $oOrder->load($orderId);
+        $oOrder->handleOrderState($state);
+        $this->assertEquals(!$oOrder->load($orderId), $shouldBeDeleted);
+    }
+    public function testHandleOrderStateProvider()
+    {
+        return [
+            'order with foreign payment method: canceled' => ['2', WdOrder::STATE_CANCELED, false],
+            'order with foreign payment method: failed' => ['2', WdOrder::STATE_FAILED, false],
+            'order to delete on canceled but not on failed: canceled' => ['1', WdOrder::STATE_CANCELED, true],
+            'order to delete on canceled but not on failed: failed' => ['1', WdOrder::STATE_FAILED, false],
+            'order to delete on both canceled and failed: canceled' => ['3', WdOrder::STATE_CANCELED, true],
+            'order to delete on both canceled and failed: failed' => ['3', WdOrder::STATE_FAILED, true],
+        ];
     }
 }

--- a/Tests/Integration/Model/OrderTest.php
+++ b/Tests/Integration/Model/OrderTest.php
@@ -181,6 +181,7 @@ class OrderTest extends Wirecard\Test\WdUnitTestCase
         $oOrder->handleOrderState($state);
         $this->assertEquals(!$oOrder->load($orderId), $shouldBeDeleted);
     }
+    
     public function testHandleOrderStateProvider()
     {
         return [

--- a/metadata.php
+++ b/metadata.php
@@ -57,6 +57,8 @@ $aModule = array(
             => \Wirecard\Oxid\Extend\Model\Order::class,
         \OxidEsales\Eshop\Application\Controller\OrderController::class
             => \Wirecard\Oxid\Extend\Controller\OrderController::class,
+        \OxidEsales\Eshop\Application\Controller\PaymentController::class
+            => \Wirecard\Oxid\Extend\Controller\PaymentController::class,
         \OxidEsales\Eshop\Application\Model\Payment::class
             => \Wirecard\Oxid\Extend\Model\Payment::class,
         \OxidEsales\Eshop\Application\Controller\Admin\PaymentMainAjax::class

--- a/translations/de/module_de_lang.php
+++ b/translations/de/module_de_lang.php
@@ -68,6 +68,7 @@ $aLang = array(
     'order_status' => 'Bestellstatus',
     'order_status_authorized' => 'Genehmigt',
     'order_status_cancelled' => 'Abgebrochen',
+    'order_status_failed' => 'Fehlgeschlagen',
     'order_status_pending' => 'Ausstehend',
     'order_status_purchased' => 'Bezahlt',
     'order_status_refunded' => 'Rückerstattet',

--- a/translations/en/module_en_lang.php
+++ b/translations/en/module_en_lang.php
@@ -68,6 +68,7 @@ $aLang = array(
     'order_status' => 'Order status',
     'order_status_authorized' => 'Authorized',
     'order_status_cancelled' => 'Cancelled',
+    'order_status_failed' => 'Failed',
     'order_status_pending' => 'Pending',
     'order_status_purchased' => 'Paid',
     'order_status_refunded' => 'Refunded',

--- a/views/admin/de/module_de_lang.php
+++ b/views/admin/de/module_de_lang.php
@@ -68,6 +68,7 @@ $aLang = array(
     'order_status' => 'Bestellstatus',
     'order_status_authorized' => 'Genehmigt',
     'order_status_cancelled' => 'Abgebrochen',
+    'order_status_failed' => 'Fehlgeschlagen',
     'order_status_pending' => 'Ausstehend',
     'order_status_purchased' => 'Bezahlt',
     'order_status_refunded' => 'Rückerstattet',

--- a/views/admin/en/module_en_lang.php
+++ b/views/admin/en/module_en_lang.php
@@ -68,6 +68,7 @@ $aLang = array(
     'order_status' => 'Order status',
     'order_status_authorized' => 'Authorized',
     'order_status_cancelled' => 'Cancelled',
+    'order_status_failed' => 'Failed',
     'order_status_pending' => 'Pending',
     'order_status_purchased' => 'Paid',
     'order_status_refunded' => 'Refunded',


### PR DESCRIPTION
### This PR

* Adds config settings to all payment methods to automatically delete an order if the associated transaction failed or is canceled
* Fixes OXID Unit Tests failing on info logs

### Notes

* If a transaction is canceled and then a new transaction is made for the same order, the old order is deleted. This is required so that OXID doesn't throw a "Duplicate order" error.

### How to Test

* Go to _Shop Settings → Payment Methods_ and select a Wirecard payment
* Make sure both "Delete Canceled Order" and "Delete Failed Order" is set to "Yes"

#### Testing canceled

* Go to the frontend and make a purchase using the payment method, but don't finish it yet
* In a new tab, go to _Administer Orders → Orders_ and confirm that the order shows up in the table
* Abort the transaction
* Go back to _Administer Orders → Orders_ and confirm that the order was deleted

#### Testing failed

* Go to the frontend and make a purchase using the payment method, but make the transaction fail (I don't know how to do this in the interface, but I'm sure there is a way)
* Check the logs and confirm that the associated order was deleted

### Jira Links

* WDPD-90: https://jira.parkside.at/browse/WDPD-90