### PR TITLE
WDPD-34 Reorder payment method edit fields

### DIFF
--- a/Model/CreditCardPaymentMethod.php
+++ b/Model/CreditCardPaymentMethod.php
@@ -159,17 +159,17 @@ class CreditCardPaymentMethod extends PaymentMethod
                 'title' => Helper::translate('config_three_d_merchant_secret'),
                 'description' => Helper::translate('config_three_d_merchant_secret_desc'),
             ],
-            'nonThreeDMaxLimit' => [
-                'type' => 'text',
-                'field' => 'oxpayments__wdoxidee_non_three_d_max_limit',
-                'title' => Helper::translate('config_ssl_max_limit'),
-                'description' => Helper::translate('config_ssl_max_limit_desc'),
-            ],
             'threeDMinLimit' => [
                 'type' => 'text',
                 'field' => 'oxpayments__wdoxidee_three_d_min_limit',
                 'title' => Helper::translate('config_three_d_min_limit'),
                 'description' => Helper::translate('config_three_d_min_limit_desc'),
+            ],
+            'nonThreeDMaxLimit' => [
+                'type' => 'text',
+                'field' => 'oxpayments__wdoxidee_non_three_d_max_limit',
+                'title' => Helper::translate('config_ssl_max_limit'),
+                'description' => Helper::translate('config_ssl_max_limit_desc'),
             ],
             'limitsCurrency' => [
                 'type' => 'select',
@@ -202,6 +202,26 @@ class CreditCardPaymentMethod extends PaymentMethod
                 ],
                 'title'       => Helper::translate('config_additional_info'),
                 'description' => Helper::translate('config_additional_info_desc'),
+            ],
+            'deleteCanceledOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_canceled_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_cancel_order'),
+                'description' => Helper::translate('config_delete_cancel_order_desc'),
+            ],
+            'deleteFailedOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_failed_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_failure_order'),
+                'description' => Helper::translate('config_delete_failure_order_desc'),
             ],
             'paymentAction' => [
                 'type'        => 'select',
@@ -246,7 +266,8 @@ class CreditCardPaymentMethod extends PaymentMethod
         return array_merge(
             parent::getPublicFieldNames(),
             ['threeDMaid', 'nonThreeDMaxLimit', 'threeDMinLimit', 'limitsCurrency',
-            'descriptor', 'additionalInfo', 'paymentAction']
+            'descriptor', 'additionalInfo', 'paymentAction', 'deleteCanceledOrder',
+            'deleteFailedOrder']
         );
     }
 }

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -191,26 +191,6 @@ abstract class PaymentMethod
                 'title' => Helper::translate('config_merchant_secret'),
                 'description' => Helper::translate('config_three_d_merchant_secret_desc'),
             ],
-            'deleteCanceledOrder' => [
-                'type' => 'select',
-                'field' => 'oxpayments__wdoxidee_delete_canceled_order',
-                'options' => [
-                    '1' => Helper::translate('yes'),
-                    '0' => Helper::translate('no'),
-                ],
-                'title' => Helper::translate('config_delete_cancel_order'),
-                'description' => Helper::translate('config_delete_cancel_order_desc'),
-            ],
-            'deleteFailedOrder' => [
-                'type' => 'select',
-                'field' => 'oxpayments__wdoxidee_delete_failed_order',
-                'options' => [
-                    '1' => Helper::translate('yes'),
-                    '0' => Helper::translate('no'),
-                ],
-                'title' => Helper::translate('config_delete_failure_order'),
-                'description' => Helper::translate('config_delete_failure_order_desc'),
-            ],
         ];
     }
 

--- a/Model/PaypalPaymentMethod.php
+++ b/Model/PaypalPaymentMethod.php
@@ -107,6 +107,26 @@ class PaypalPaymentMethod extends PaymentMethod
                 'title'       => Helper::translate('config_additional_info'),
                 'description' => Helper::translate('config_additional_info_desc'),
             ],
+            'deleteCanceledOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_canceled_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_cancel_order'),
+                'description' => Helper::translate('config_delete_cancel_order_desc'),
+            ],
+            'deleteFailedOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_failed_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_failure_order'),
+                'description' => Helper::translate('config_delete_failure_order_desc'),
+            ],
             'paymentAction' => [
                 'type'        => 'select',
                 'field'       => 'oxpayments__wdoxidee_transactionaction',
@@ -128,6 +148,9 @@ class PaypalPaymentMethod extends PaymentMethod
      */
     public function getPublicFieldNames()
     {
-        return array_merge(parent::getPublicFieldNames(), ['basket', 'descriptor', 'additionalInfo', 'paymentAction']);
+        return array_merge(
+            parent::getPublicFieldNames(),
+            ['basket', 'descriptor', 'additionalInfo', 'paymentAction', 'deleteCanceledOrder', 'deleteFailedOrder']
+        );
     }
 }

--- a/Model/SofortPaymentMethod.php
+++ b/Model/SofortPaymentMethod.php
@@ -108,6 +108,26 @@ class SofortPaymentMethod extends PaymentMethod
                 'title'       => Helper::translate('config_additional_info'),
                 'description' => Helper::translate('config_additional_info_desc'),
             ],
+            'deleteCanceledOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_canceled_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_cancel_order'),
+                'description' => Helper::translate('config_delete_cancel_order_desc'),
+            ],
+            'deleteFailedOrder' => [
+                'type' => 'select',
+                'field' => 'oxpayments__wdoxidee_delete_failed_order',
+                'options' => [
+                    '1' => Helper::translate('yes'),
+                    '0' => Helper::translate('no'),
+                ],
+                'title' => Helper::translate('config_delete_failure_order'),
+                'description' => Helper::translate('config_delete_failure_order_desc'),
+            ],
             'countryCode' => [
                 'type'        => 'text',
                 'field'       => 'oxpayments__wdoxidee_countrycode',
@@ -140,6 +160,9 @@ class SofortPaymentMethod extends PaymentMethod
      */
     public function getPublicFieldNames()
     {
-        return array_merge(parent::getPublicFieldNames(), ['additionalInfo', 'countryCode', 'logoType']);
+        return array_merge(
+            parent::getPublicFieldNames(),
+            ['additionalInfo', 'countryCode', 'logoType', 'deleteCanceledOrder', 'deleteFailedOrder']
+        );
     }
 }


### PR DESCRIPTION
### This PR

* Reorder Credit Card limits config fields
* Unify order of the payment method fields

### TODO

* Update the wiki screenshot, because new items are added - Delete Canceled Order, Delete Failed Order

### How to Test

* Go to administration
* In the Credit Card payment method page, check the fields order
