### PR TITLE
WDPD-66 Show chat only if payment is available

### DIFF
--- a/views/admin/blocks/admin_payment_main_editor.tpl
+++ b/views/admin/blocks/admin_payment_main_editor.tpl
@@ -1,5 +1,5 @@
 [{$smarty.block.parent}]
 
-[{if $edit->isCustomPaymentMethod()}]
+[{if $edit && $edit->isCustomPaymentMethod()}]
   [{include file="live_chat.tpl"}]
 [{/if}]


### PR DESCRIPTION
### This PR

* Fix default payment admin page when no payment method is selected

### How to Test

* Log into Admin
* Go to Payment Method settings
* Check the default payment page when no payment method is selected
