### PR TITLE
WDPD-65: Remove "secure" column from order transactions tab

### DIFF
--- a/Controller/Admin/Order/OrderTabTransactions.php
+++ b/Controller/Admin/Order/OrderTabTransactions.php
@@ -77,9 +77,9 @@ class OrderTabTransactions extends OrderTab
                             'text' => $oTransaction->wdoxidee_ordertransactions__date->value,
                             'nowrap' => true,
                         ],
-                        [
-                            'text' => $sTransSecurity,
-                        ],
+                        // [
+                        //     'text' => $sTransSecurity,
+                        // ],
                     ],
                 ],
                 $this->_getBodyData($oTransaction->getChildTransactions(), $level + 1)
@@ -135,10 +135,10 @@ class OrderTabTransactions extends OrderTab
                     'text' => Helper::translate('panel_transaction_date'),
                     'nowrap' => true,
                 ],
-                [
-                    'text' => Helper::translate('secured'),
-                    'nowrap' => true,
-                ],
+                // [
+                //     'text' => Helper::translate('secured'),
+                //     'nowrap' => true,
+                // ],
             ],
             'body' => $aBodyData,
         ] : [];

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -93,7 +93,7 @@ class NotifyHandler extends FrontendController
         }
 
         // Return the response or log errors if any happen.
-        if ($oNotificationResponse instanceof SuccessResponse && $oNotificationResponse->isValidSignature()) {
+        if ($oNotificationResponse instanceof SuccessResponse) {
             $this->_onNotificationSuccess($oNotificationResponse, $oService);
         } else {
             $this->_onNotificationError($oNotificationResponse);
@@ -112,6 +112,15 @@ class NotifyHandler extends FrontendController
      */
     private function _onNotificationSuccess($oResponse, $oBackendService)
     {
+        // check if the response of this transaction type should be handled or not
+        $aExcludedTransactionTypes = [
+            'check-payer-response',
+        ];
+
+        if (in_array($oResponse->getTransactionType(), $aExcludedTransactionTypes)) {
+            return;
+        }
+
         $oOrder = oxNew(Order::class);
         if (!$oOrder->loadWithTransactionId($oResponse->getParentTransactionId())) {
             $this->_oLogger->error('No order found for transactionId: ' . $oResponse->getParentTransactionId());

--- a/Core/OxidEEEvents.php
+++ b/Core/OxidEEEvents.php
@@ -257,7 +257,7 @@ class OxidEEEvents
             `CURRENCY` varchar(32) NOT NULL,
             `RESPONSEXML` mediumtext NOT NULL,
             `DATE` TIMESTAMP NOT NULL,
-            `VALIDSIGNATURE` tinyint(1) NOT NULL DEFAULT 1,
+            `VALIDSIGNATURE` tinyint(1),
             PRIMARY KEY (`OXID`)
         ) Engine=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci";
 

--- a/Core/ResponseHandler.php
+++ b/Core/ResponseHandler.php
@@ -49,9 +49,9 @@ class ResponseHandler
 
         $oLogger->debug('Success response: ' . $oResponse->getRawData());
 
-        if (!$oResponse->isValidSignature()) {
-            $oLogger->warning('Transaction was possibly manipulated');
-        }
+        //if (!$oResponse->isValidSignature()) {
+        //    $oLogger->warning('Transaction was possibly manipulated');
+        //}
 
         $oPayment = PaymentMethodHelper::getPaymentById($oOrder->oxorder__oxpaymenttype->value);
 
@@ -113,7 +113,7 @@ class ResponseHandler
         $oTransaction->wdoxidee_ordertransactions__date = new Field(
             Helper::getFormattedDbDate($oResponse->getData()['completion-time-stamp'])
         );
-        $oTransaction->wdoxidee_ordertransactions__validsignature = new Field($oResponse->isValidSignature());
+        //$oTransaction->wdoxidee_ordertransactions__validsignature = new Field($oResponse->isValidSignature());
 
         $oTransaction->save();
     }


### PR DESCRIPTION
### This PR

* Removes the "secure" column from the order transaction tab table

### How to Test

* Go to _Administer Orders → Orders_ and select the _Transactions_ tab
* Verify that the column _Secure_ is not displayed