### PR TITLE
WDPD-121 Add payment method sorting

### DIFF
--- a/Core/OxidEEEvents.php
+++ b/Core/OxidEEEvents.php
@@ -316,16 +316,17 @@ class OxidEEEvents
         );
 
         $sQuery = "INSERT INTO " . self::PAYMENT_TABLE . "(`OXID`, `OXACTIVE`, `OXTOAMOUNT`, `OXDESC`, `OXDESC_1`,
-         `WDOXIDEE_LOGO`, `WDOXIDEE_TRANSACTIONACTION`, `WDOXIDEE_APIURL`, `WDOXIDEE_MAID`, `WDOXIDEE_SECRET`,
-         `WDOXIDEE_THREE_D_MAID`, `WDOXIDEE_THREE_D_SECRET`, `WDOXIDEE_NON_THREE_D_MAX_LIMIT`,
-         `WDOXIDEE_THREE_D_MIN_LIMIT`, `WDOXIDEE_LIMITS_CURRENCY`,
-         `WDOXIDEE_HTTPUSER`, `WDOXIDEE_HTTPPASS`, `WDOXIDEE_ISOURS`, `WDOXIDEE_BASKET`,
-         `WDOXIDEE_DESCRIPTOR`, `WDOXIDEE_ADDITIONAL_INFO`, `WDOXIDEE_COUNTRYCODE`, `WDOXIDEE_LOGOVARIANT`) VALUES (
+         `OXSORT`, `WDOXIDEE_LOGO`, `WDOXIDEE_TRANSACTIONACTION`, `WDOXIDEE_APIURL`, `WDOXIDEE_MAID`,
+         `WDOXIDEE_SECRET`, `WDOXIDEE_THREE_D_MAID`, `WDOXIDEE_THREE_D_SECRET`, `WDOXIDEE_NON_THREE_D_MAX_LIMIT`,
+         `WDOXIDEE_THREE_D_MIN_LIMIT`, `WDOXIDEE_LIMITS_CURRENCY`, `WDOXIDEE_HTTPUSER`, `WDOXIDEE_HTTPPASS`,
+         `WDOXIDEE_ISOURS`, `WDOXIDEE_BASKET`, `WDOXIDEE_DESCRIPTOR`, `WDOXIDEE_ADDITIONAL_INFO`,
+         `WDOXIDEE_COUNTRYCODE`, `WDOXIDEE_LOGOVARIANT`) VALUES (
              '{$oPayment->oxid}',
              '{$oPayment->oxactive}',
              '{$oPayment->oxtoamount}',
              '{$oPayment->oxdesc}',
              '{$oPayment->oxdesc_1}',
+             '{$oPayment->oxsort}',
              '{$oPayment->wdoxidee_logo}',
              '{$oPayment->wdoxidee_transactionaction}',
              '{$oPayment->wdoxidee_apiurl}',

--- a/default_payment_config.xml
+++ b/default_payment_config.xml
@@ -9,28 +9,12 @@
 
 <payments>
     <payment>
-        <oxid>wdpaypal</oxid>
-        <oxactive>0</oxactive>
-        <oxtoamount>1000000</oxtoamount>
-        <oxdesc>Wirecard PayPal</oxdesc>
-        <oxdesc_1>Wirecard PayPal</oxdesc_1>
-        <wdoxidee_logo>paypal.png</wdoxidee_logo>
-        <wdoxidee_transactionaction>pay</wdoxidee_transactionaction>
-        <wdoxidee_apiurl>https://api-test.wirecard.com</wdoxidee_apiurl>
-        <wdoxidee_maid>2a0e9351-24ed-4110-9a1b-fd0fee6bec26</wdoxidee_maid>
-        <wdoxidee_secret>dbc5a498-9a66-43b9-bf1d-a618dd399684</wdoxidee_secret>
-        <wdoxidee_httpuser>70000-APITEST-AP</wdoxidee_httpuser>
-        <wdoxidee_httppass>qD2wzQ_hrc!8</wdoxidee_httppass>
-        <wdoxidee_basket>1</wdoxidee_basket>
-        <wdoxidee_descriptor>1</wdoxidee_descriptor>
-        <wdoxidee_additional_info>1</wdoxidee_additional_info>
-    </payment>
-    <payment>
         <oxid>wdcreditcard</oxid>
         <oxactive>0</oxactive>
         <oxtoamount>1000000</oxtoamount>
         <oxdesc>Wirecard Kreditkarte</oxdesc>
         <oxdesc_1>Wirecard Credit Card</oxdesc_1>
+        <oxsort>10</oxsort>
         <wdoxidee_logo>creditcard.png</wdoxidee_logo>
         <wdoxidee_transactionaction>pay</wdoxidee_transactionaction>
         <wdoxidee_apiurl>https://api-test.wirecard.com</wdoxidee_apiurl>
@@ -47,11 +31,30 @@
         <wdoxidee_additional_info>1</wdoxidee_additional_info>
     </payment>
     <payment>
+        <oxid>wdpaypal</oxid>
+        <oxactive>0</oxactive>
+        <oxtoamount>1000000</oxtoamount>
+        <oxdesc>Wirecard PayPal</oxdesc>
+        <oxdesc_1>Wirecard PayPal</oxdesc_1>
+        <oxsort>20</oxsort>
+        <wdoxidee_logo>paypal.png</wdoxidee_logo>
+        <wdoxidee_transactionaction>pay</wdoxidee_transactionaction>
+        <wdoxidee_apiurl>https://api-test.wirecard.com</wdoxidee_apiurl>
+        <wdoxidee_maid>2a0e9351-24ed-4110-9a1b-fd0fee6bec26</wdoxidee_maid>
+        <wdoxidee_secret>dbc5a498-9a66-43b9-bf1d-a618dd399684</wdoxidee_secret>
+        <wdoxidee_httpuser>70000-APITEST-AP</wdoxidee_httpuser>
+        <wdoxidee_httppass>qD2wzQ_hrc!8</wdoxidee_httppass>
+        <wdoxidee_basket>1</wdoxidee_basket>
+        <wdoxidee_descriptor>1</wdoxidee_descriptor>
+        <wdoxidee_additional_info>1</wdoxidee_additional_info>
+    </payment>
+    <payment>
         <oxid>wdsofortbanking</oxid>
         <oxactive>0</oxactive>
         <oxtoamount>1000000</oxtoamount>
         <oxdesc>Wirecard Sofort.</oxdesc>
         <oxdesc_1>Wirecard Sofort.</oxdesc_1>
+        <oxsort>30</oxsort>
         <wdoxidee_logo>https://cdn.klarna.com/1.0/shared/image/generic/badge/%s/pay_now/%s/pink.svg</wdoxidee_logo>
         <wdoxidee_transactionaction>pay</wdoxidee_transactionaction>
         <wdoxidee_apiurl>https://api-test.wirecard.com</wdoxidee_apiurl>


### PR DESCRIPTION
### This PR

* uses oxsort value for sorting Wirecard payment methods (Credit card is on the first place, and other payment methods are sorted alphabetically).

### How to Test

* Activate the module
* Go to Shop Settings -> Payment Methods
* Wirecard payment methods are now being sorted according to the given rules. Merchant can re-sort them by changing the value of "Sorting". Payment with the lowest value for "Sorting" field comes first on the sorting list.

### Jira Links

* https://jira.parkside.at/browse/WDPD-121