### PR TITLE
WDPD-126 Add live chat button to 'Transactions' tab

### DIFF
--- a/Controller/Admin/Order/OrderTab.php
+++ b/Controller/Admin/Order/OrderTab.php
@@ -53,9 +53,6 @@ class OrderTab extends Tab
     {
         parent::__construct();
 
-        $this->oOrder = oxNew(Order::class);
-        $this->oTransaction = oxNew(Transaction::class);
-
         if ($this->_isListObjectIdSet()) {
             $this->oOrder->load($this->sListObjectId);
             $this->oTransaction->loadWithTransactionId($this->oOrder->oxorder__wdoxidee_transactionid->value);
@@ -84,17 +81,5 @@ class OrderTab extends Tab
         }
 
         return $sTemplate;
-    }
-
-    /**
-     * Returns true if the payment is one of the module's.
-     *
-     * @return bool
-     *
-     * @since 1.0.1
-     */
-    public function isCustomPaymentMethod()
-    {
-        return $this->oOrder->isCustomPaymentMethod();
     }
 }

--- a/Controller/Admin/Order/OrderTab.php
+++ b/Controller/Admin/Order/OrderTab.php
@@ -9,12 +9,9 @@
 
 namespace Wirecard\Oxid\Controller\Admin\Order;
 
-use OxidEsales\Eshop\Application\Model\Order;
-
 use Wirecard\Oxid\Controller\Admin\Tab;
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\ResponseMapper;
-use Wirecard\Oxid\Model\Transaction;
 
 /**
  * Controls the view for a single order tab.
@@ -23,20 +20,6 @@ use Wirecard\Oxid\Model\Transaction;
  */
 class OrderTab extends Tab
 {
-    /**
-     * @var Transaction
-     *
-     * @since 1.0.0
-     */
-    protected $oTransaction;
-
-    /**
-     * @var Order
-     *
-     * @since 1.0.0
-     */
-    protected $oOrder;
-
     /**
      * @var ResponseMapper
      *

--- a/Controller/Admin/Order/OrderTab.php
+++ b/Controller/Admin/Order/OrderTab.php
@@ -85,4 +85,16 @@ class OrderTab extends Tab
 
         return $sTemplate;
     }
+
+    /**
+     * Returns true if the payment is one of the module's.
+     *
+     * @return bool
+     *
+     * @since 1.0.1
+     */
+    public function isCustomPaymentMethod()
+    {
+        return $this->oOrder->isCustomPaymentMethod();
+    }
 }

--- a/Controller/Admin/Tab.php
+++ b/Controller/Admin/Tab.php
@@ -10,8 +10,10 @@
 namespace Wirecard\Oxid\Controller\Admin;
 
 use Wirecard\Oxid\Core\Helper;
+use Wirecard\Oxid\Model\Transaction;
 
 use OxidEsales\Eshop\Application\Controller\Admin\AdminDetailsController;
+use OxidEsales\Eshop\Application\Model\Order;
 
 /**
  * Controls the view for a single tab in the admin details.
@@ -45,6 +47,8 @@ class Tab extends AdminDetailsController
     {
         parent::__construct();
 
+        $this->oOrder = oxNew(Order::class);
+        $this->oTransaction = oxNew(Transaction::class);
         $this->sListObjectId = $this->getEditObjectId();
     }
 
@@ -66,6 +70,18 @@ class Tab extends AdminDetailsController
         ]);
 
         return $sTemplate;
+    }
+
+    /**
+     * Determines whether the live chat should be displayed in the tab.
+     *
+     * @return boolean
+     *
+     * @since 1.0.1
+     */
+    public function shouldDisplayLiveChat()
+    {
+        return $this->oOrder->isCustomPaymentMethod();
     }
 
     /**

--- a/Controller/Admin/Tab.php
+++ b/Controller/Admin/Tab.php
@@ -25,6 +25,20 @@ class Tab extends AdminDetailsController
     const NOTHING_SELECTED = '-1';
 
     /**
+     * @var Transaction
+     *
+     * @since 1.0.1
+     */
+    protected $oTransaction;
+
+    /**
+     * @var Order
+     *
+     * @since 1.0.1
+     */
+    protected $oOrder;
+
+    /**
      * @var string
      *
      * @since 1.0.0

--- a/Controller/Admin/Transaction/TransactionTab.php
+++ b/Controller/Admin/Transaction/TransactionTab.php
@@ -14,7 +14,6 @@ use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\ResponseMapper;
 use Wirecard\Oxid\Model\Transaction;
 
-use OxidEsales\Eshop\Application\Model\Order;
 use OxidEsales\Eshop\Application\Model\Payment;
 
 /**
@@ -24,20 +23,6 @@ use OxidEsales\Eshop\Application\Model\Payment;
  */
 class TransactionTab extends Tab
 {
-    /**
-     * @var Transaction
-     *
-     * @since 1.0.0
-     */
-    protected $oTransaction;
-
-    /**
-     * @var Order
-     *
-     * @since 1.0.0
-     */
-    protected $oOrder;
-
     /**
      * @var Payment
      *

--- a/Controller/Admin/Transaction/TransactionTab.php
+++ b/Controller/Admin/Transaction/TransactionTab.php
@@ -64,8 +64,6 @@ class TransactionTab extends Tab
     {
         parent::__construct();
 
-        $this->oTransaction = oxNew(Transaction::class);
-        $this->oOrder = oxNew(Order::class);
         $this->oPayment = oxNew(Payment::class);
 
         if ($this->_isListObjectIdSet()) {

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -13,7 +13,6 @@ use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Exception\StandardException;
 
 use Wirecard\Oxid\Controller\Admin\Transaction\TransactionTab;
-use Wirecard\Oxid\Model\Transaction;
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\TransactionHandler;
 use Wirecard\Oxid\Core\PaymentMethodFactory;
@@ -31,13 +30,6 @@ class TransactionTabPostProcessing extends TransactionTab
 {
     const KEY_ACTION = 'action';
     const KEY_AMOUNT = 'amount';
-
-    /**
-     * @var Transaction
-     *
-     * @since 1.0.0
-     */
-    protected $oTransaction;
 
     /**
      * @var \Psr\Log\LoggerInterface

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -12,7 +12,7 @@ namespace Wirecard\Oxid\Controller\Admin\Transaction;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Exception\StandardException;
 
-use Wirecard\Oxid\Controller\Admin\Tab;
+use Wirecard\Oxid\Controller\Admin\Transaction\TransactionTab;
 use Wirecard\Oxid\Model\Transaction;
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\TransactionHandler;
@@ -27,7 +27,7 @@ use Wirecard\PaymentSdk\Config\Config;
  *
  * @since 1.0.0
  */
-class TransactionTabPostProcessing extends Tab
+class TransactionTabPostProcessing extends TransactionTab
 {
     const KEY_ACTION = 'action';
     const KEY_AMOUNT = 'amount';
@@ -82,8 +82,6 @@ class TransactionTabPostProcessing extends Tab
     public function __construct()
     {
         parent::__construct();
-
-        $this->oTransaction = oxNew(Transaction::class);
 
         $this->_oLogger = Registry::getLogger();
 

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -17,6 +17,7 @@ use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\TransactionHandler;
 use Wirecard\Oxid\Core\PaymentMethodFactory;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
+use Wirecard\Oxid\Model\Transaction;
 use Wirecard\PaymentSdk\Transaction\SofortTransaction;
 use Wirecard\PaymentSdk\BackendService;
 use Wirecard\PaymentSdk\Config\Config;

--- a/Tests/Unit/Controller/Admin/Transaction/TransactionTabPostProcessingTest.php
+++ b/Tests/Unit/Controller/Admin/Transaction/TransactionTabPostProcessingTest.php
@@ -45,6 +45,8 @@ class TransactionTabPostProcessingTest extends Wirecard\Test\WdUnitTestCase
 
     protected function dbData()
     {
+        $sEncodedXml = base64_encode(file_get_contents(dirname(__FILE__) . '/../../../../resources/success_response_transaction_handler.xml'));
+
         return [
             [
                 'table' => 'oxorder',
@@ -55,9 +57,9 @@ class TransactionTabPostProcessingTest extends Wirecard\Test\WdUnitTestCase
             ],
             [
                 'table' => 'wdoxidee_ordertransactions',
-                'columns' => ['oxid', 'orderid', 'ordernumber', 'transactionid', 'parenttransactionid', 'action', 'type', 'state', 'amount', 'currency'],
+                'columns' => ['oxid', 'orderid', 'ordernumber', 'transactionid', 'parenttransactionid', 'action', 'type', 'state', 'amount', 'currency', 'responsexml'],
                 'rows' => [
-                    ['transaction 1', 'oxid 1', 2, 'transaction 1', null, 'reserve', 'authorization', 'success', 100, 'EUR'],
+                    ['transaction 1', 'oxid 1', 2, 'transaction 1', null, 'reserve', 'authorization', 'success', 100, 'EUR', $sEncodedXml],
                 ]
             ],
         ];

--- a/views/admin/tpl/tab_post_processing.tpl
+++ b/views/admin/tpl/tab_post_processing.tpl
@@ -50,7 +50,9 @@
     </script>
 [{/if}]
 
-[{include file="live_chat.tpl"}]
+[{if $oView->shouldDisplayLiveChat()}]
+  [{include file="live_chat.tpl"}]
+[{/if}]
 
 [{include file="bottomnaviitem.tpl"}]
 

--- a/views/admin/tpl/tab_simple.tpl
+++ b/views/admin/tpl/tab_simple.tpl
@@ -66,7 +66,7 @@ function wdCopyToClipboard(text)
     <em>[{$emptyText}]</em>
 [{/if}]
 
-[{if $oView->isCustomPaymentMethod()}]
+[{if $oView->shouldDisplayLiveChat()}]
   [{include file="live_chat.tpl"}]
 [{/if}]
 

--- a/views/admin/tpl/tab_simple.tpl
+++ b/views/admin/tpl/tab_simple.tpl
@@ -66,7 +66,9 @@ function wdCopyToClipboard(text)
     <em>[{$emptyText}]</em>
 [{/if}]
 
-[{include file="live_chat.tpl"}]
+[{if $oView->isCustomPaymentMethod()}]
+  [{include file="live_chat.tpl"}]
+[{/if}]
 
 [{include file="bottomnaviitem.tpl"}]
 

--- a/views/admin/tpl/tab_table.tpl
+++ b/views/admin/tpl/tab_table.tpl
@@ -71,7 +71,7 @@
     <em>[{$emptyText}]</em>
 [{/if}]
 
-[{if $oView->isCustomPaymentMethod()}]
+[{if $oView->shouldDisplayLiveChat()}]
   [{include file="live_chat.tpl"}]
 [{/if}]
 

--- a/views/admin/tpl/tab_table.tpl
+++ b/views/admin/tpl/tab_table.tpl
@@ -71,6 +71,10 @@
     <em>[{$emptyText}]</em>
 [{/if}]
 
+[{if $oView->isCustomPaymentMethod()}]
+  [{include file="live_chat.tpl"}]
+[{/if}]
+
 [{include file="bottomnaviitem.tpl"}]
 
 [{include file="bottomitem.tpl"}]


### PR DESCRIPTION
### This PR

* adds the live chat button to the 'Transactions' tab in the orders overview
* improves the display logic of the live chat button in the two transaction management tabs in the orders overview, so it is only shown for orders that were paid with a Wirecard payment method.

### Jira Links

* https://jira.parkside.at/browse/WDPD-126