### PR TITLE
WDPD-131: Create Selenium Happy Flow Tests for Credit Card

### DIFF
--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\Oxid\Tests\Acceptance;
+
+use Wirecard\Oxid\Model\CreditCardPaymentMethod;
+
+/**
+ * Acceptance tests for the Credit Card checkout flow.
+ */
+class CreditCardCheckoutTest extends CheckoutTestCase
+{
+    public function getPaymentMethod()
+    {
+        return new CreditCardPaymentMethod();
+    }
+
+    public function testCheckoutForPurchaseNonThreeD()
+    {
+        $this->setPaymentActionPurchase();
+        $this->forceNonThreeD();
+        $this->goThroughCheckout();
+
+        $this->assertPaymentSuccessful();
+    }
+
+    public function testCheckoutForAuthorizeNonThreeD()
+    {
+        $this->setPaymentActionAuthorize();
+        $this->forceNonThreeD();
+        $this->goThroughCheckout();
+
+        $this->assertPaymentSuccessful();
+    }
+
+    private function forceThreeD()
+    {
+        $this->executeSql("UPDATE `oxpayments`
+            SET `WDOXIDEE_MAID` = '', `WDOXIDEE_SECRET` = ''
+            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+    }
+
+    private function forceNonThreeD()
+    {
+        $this->executeSql("UPDATE `oxpayments`
+            SET `WDOXIDEE_THREE_D_MAID` = '', `WDOXIDEE_THREE_D_SECRET` = ''
+            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+    }
+
+    public function goThroughCheckout()
+    {
+        $this->openShop();
+        $this->loginMockUserToFrontend();
+        $this->addMockArticleToBasket();
+
+        // Step 1: Cart
+        $this->continueToNextStep();
+
+        // Step 2: Address
+        $this->continueToNextStep();
+
+        // Step 3: Pay
+        $this->click(sprintf(
+            $this->getLocator('checkout.paymentMethod'),
+            $this->paymentMethod::getName(true)
+        ));
+        $this->continueToNextStep();
+
+        // Step 4: Order
+        $rootFrame = $this->getSelectedFrame();
+        $this->selectFrame($this->getLocator('external.creditcard.frame'));
+
+        $this->type(
+            $this->getLocator('external.creditcard.firstName'),
+            $this->getConfigValue('payments.creditcard.firstName')
+        );
+        $this->type(
+            $this->getLocator('external.creditcard.lastName'),
+            $this->getConfigValue('payments.creditcard.lastName')
+        );
+        $this->type(
+            $this->getLocator('external.creditcard.cardNumber'),
+            $this->getConfigValue('payments.creditcard.cardNumber')
+        );
+        $this->keyUp($this->getLocator('external.creditcard.cardNumber'), ' '); // forces validation
+        $this->type(
+            $this->getLocator('external.creditcard.cvv'),
+            $this->getConfigValue('payments.creditcard.cvv')
+        );
+        $this->select(
+            $this->getLocator('external.creditcard.expiryMonth'),
+            $this->getConfigValue('payments.creditcard.expiryMonth')
+        );
+        $this->select(
+            $this->getLocator('external.creditcard.expiryYear'),
+            $this->getConfigValue('payments.creditcard.expiryYear')
+        );
+
+        $this->selectFrame($rootFrame);
+        $this->continueToNextStep();
+    }
+}

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -97,9 +97,10 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         // Step 4: Order
         $rootFrame = $this->getSelectedFrame();
 
-        $this->waitForElement($this->getLocator('external.creditcard.frame'));
+        $this->waitForElement($this->getLocator('external.creditcard.frame'), 30);
         $this->selectFrame($this->getLocator('external.creditcard.frameId'));
 
+        $this->waitForElement($this->getLocator('external.creditcard.firstName'));
         $this->type(
             $this->getLocator('external.creditcard.firstName'),
             $this->getConfigValue('payments.creditcard.firstName')

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -103,28 +103,28 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         $this->waitForElement($this->getLocator('external.creditcard.firstName'));
         $this->type(
             $this->getLocator('external.creditcard.firstName'),
-            $this->getConfigValue('payments.creditcard.firstName')
+            $this->getConfig('payments.creditcard.firstName')
         );
         $this->type(
             $this->getLocator('external.creditcard.lastName'),
-            $this->getConfigValue('payments.creditcard.lastName')
+            $this->getConfig('payments.creditcard.lastName')
         );
         $this->type(
             $this->getLocator('external.creditcard.cardNumber'),
-            $this->getConfigValue('payments.creditcard.cardNumber')
+            $this->getConfig('payments.creditcard.cardNumber')
         );
         $this->fireEvent($this->getLocator('external.creditcard.cardNumber'), 'keyup');
         $this->type(
             $this->getLocator('external.creditcard.cvv'),
-            $this->getConfigValue('payments.creditcard.cvv')
+            $this->getConfig('payments.creditcard.cvv')
         );
         $this->select(
             $this->getLocator('external.creditcard.expiryMonth'),
-            $this->getConfigValue('payments.creditcard.expiryMonth')
+            $this->getConfig('payments.creditcard.expiryMonth')
         );
         $this->select(
             $this->getLocator('external.creditcard.expiryYear'),
-            $this->getConfigValue('payments.creditcard.expiryYear')
+            $this->getConfig('payments.creditcard.expiryYear')
         );
 
         $this->selectFrame($rootFrame);
@@ -136,7 +136,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         $this->waitForElement($this->getLocator('external.creditcard.password'), 30);
         $this->type(
             $this->getLocator('external.creditcard.password'),
-            $this->getConfigValue('payments.creditcard.password')
+            $this->getConfig('payments.creditcard.password')
         );
         $this->click($this->getLocator('external.creditcard.continueButton'));
     }

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -74,7 +74,9 @@ class CreditCardCheckoutTest extends CheckoutTestCase
 
         // Step 4: Order
         $rootFrame = $this->getSelectedFrame();
-        $this->selectFrame($this->getLocator('external.creditcard.frame'));
+
+        $this->waitForElement($this->getLocator('external.creditcard.frame'));
+        $this->selectFrame($this->getLocator('external.creditcard.frameId'));
 
         $this->type(
             $this->getLocator('external.creditcard.firstName'),

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -39,6 +39,28 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         $this->assertPaymentSuccessful();
     }
 
+    public function testCheckoutForPurchaseThreeD()
+    {
+        $this->setPaymentActionPurchase();
+        $this->forceThreeD();
+        $this->goThroughCheckout();
+        $this->goThroughExternalFlow();
+        $this->waitForRedirectConfirmation();
+
+        $this->assertPaymentSuccessful();
+    }
+
+    public function testCheckoutForAuthorizeThreeD()
+    {
+        $this->setPaymentActionAuthorize();
+        $this->forceThreeD();
+        $this->goThroughCheckout();
+        $this->goThroughExternalFlow();
+        $this->waitForRedirectConfirmation();
+
+        $this->assertPaymentSuccessful();
+    }
+
     private function forceThreeD()
     {
         $this->executeSql("UPDATE `oxpayments`
@@ -106,5 +128,15 @@ class CreditCardCheckoutTest extends CheckoutTestCase
 
         $this->selectFrame($rootFrame);
         $this->continueToNextStep();
+    }
+
+    private function goThroughExternalFlow()
+    {
+        $this->waitForElement($this->getLocator('external.creditcard.password'), 30);
+        $this->type(
+            $this->getLocator('external.creditcard.password'),
+            $this->getConfigValue('payments.creditcard.password')
+        );
+        $this->click($this->getLocator('external.creditcard.continueButton'));
     }
 }

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -112,7 +112,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.creditcard.cardNumber'),
             $this->getConfigValue('payments.creditcard.cardNumber')
         );
-        $this->keyUp($this->getLocator('external.creditcard.cardNumber'), ' '); // forces validation
+        $this->fireEvent($this->getLocator('external.creditcard.cardNumber'), 'keyup');
         $this->type(
             $this->getLocator('external.creditcard.cvv'),
             $this->getConfigValue('payments.creditcard.cvv')

--- a/Tests/Acceptance/inc/config.json
+++ b/Tests/Acceptance/inc/config.json
@@ -4,6 +4,15 @@
       "email": "paypal.buyer2@wirecard.com",
       "password": "Wirecardbuyer"
     },
+    "creditcard": {
+      "firstName": "First",
+      "lastName": "Last",
+      "cardNumber": "4012000300001003",
+      "cvv": "003",
+      "expiryMonth": "01",
+      "expiryYear": "2023",
+      "password": "wirecard"
+    },
     "sofort": {
       "country": "AT",
       "bank": "00000",

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -10,6 +10,15 @@
       "login": "btnLogin",
       "nextStep": "//*[contains(@class, 'continueButton')]"
     },
+    "creditcard": {
+      "frame": "2",
+      "firstName": "first_name",
+      "lastName": "last_name",
+      "cardNumber": "account_number",
+      "cvv": "card_security_code",
+      "expiryMonth": "expiration_month_list",
+      "expiryYear": "expiration_year_list"
+    },
     "sofort": {
       "country": "MultipaysSessionSenderCountryId",
       "bank": "BankCodeSearch",

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -11,7 +11,8 @@
       "nextStep": "//*[contains(@class, 'continueButton')]"
     },
     "creditcard": {
-      "frame": "2",
+      "frame": "//iframe[@class='wirecard-seamless-frame']",
+      "frameId": "2",
       "firstName": "first_name",
       "lastName": "last_name",
       "cardNumber": "account_number",

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -18,7 +18,9 @@
       "cardNumber": "account_number",
       "cvv": "card_security_code",
       "expiryMonth": "expiration_month_list",
-      "expiryYear": "expiration_year_list"
+      "expiryYear": "expiration_year_list",
+      "password": "password",
+      "continueButton": "//input[@name='authenticate']"
     },
     "sofort": {
       "country": "MultipaysSessionSenderCountryId",


### PR DESCRIPTION
### This PR

* Adds Credit Card checkout tests for purchase/authorization actions
* Adds Credit Card checkout tests for 3d/non-3d authorization

### How to Test

* Run `rake runtests_selenium` and check if all tests succeed
* For information on how to see the Selenium tests being run in the browser, follow the instructions in this PR: https://github.com/wirecard/oxid-ee/pull/79

### Jira Links

* WDPD-131: https://jira.parkside.at/browse/WDPD-131