### PR TITLE
WDPD-144 Improve floating-point calculation of post-processing transactions

### DIFF
--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -251,7 +251,8 @@ class TransactionTabPostProcessing extends TransactionTab
      */
     private function _isPositiveBelowMax($fAmount, $fMaxAmount)
     {
-        return $fAmount > 0 && $fAmount <= $fMaxAmount;
+        return $fAmount > 0 &&
+            ((bcsub($fAmount, $fMaxAmount, Helper::BCSUB_SCALE) / $fMaxAmount) < Helper::FLOATING_POINT_EPSILON);
     }
 
     /**

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -251,7 +251,7 @@ class TransactionTabPostProcessing extends TransactionTab
      */
     private function _isPositiveBelowMax($fAmount, $fMaxAmount)
     {
-        return $fAmount > 0 &&
+        return $fAmount > 0 && $fMaxAmount > 0 &&
             ((bcsub($fAmount, $fMaxAmount, Helper::BCSUB_SCALE) / $fMaxAmount) < Helper::FLOATING_POINT_EPSILON);
     }
 

--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -38,7 +38,7 @@ class Helper
 
     const FLOATING_POINT_EPSILON = 0.000001;
     const BCSUB_SCALE = 12;
-    const ROUND_PRECISION = 3;
+    const ROUND_PRECISION_FALLBACK = 3;
 
     /**
      * Gets the translation for a given key.
@@ -69,6 +69,28 @@ class Helper
     public static function createDeviceFingerprint($sMaid, $sSessionId = null)
     {
         return $sMaid . '_' . $sSessionId;
+    }
+
+    /**
+     * Gets the currency round precision for a given currency.
+     * If the merchant has set the precision in the admin area this value will be returned,
+     * otherwise the fallback value set in this helper class.
+     *
+     * @param string $sCurrencyName
+     *
+     * @return integer round precision
+     *
+     * @since 1.0.1
+     */
+    public static function getCurrencyRoundPrecision($sCurrencyName)
+    {
+        $oCurrency = Registry::getConfig()->getCurrencyObject($sCurrencyName);
+
+        if ($oCurrency && isset($oCurrency->decimal)) {
+            return $oCurrency->decimal;
+        }
+
+        return self::ROUND_PRECISION_FALLBACK;
     }
 
     /**

--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -36,6 +36,10 @@ class Helper
     const PLUGIN_VERSION_KEY = 'pluginVersion';
     const SHOP_SYSTEM_VALUE = 'OXID';
 
+    const FLOATING_POINT_EPSILON = 0.000001;
+    const BCSUB_SCALE = 12;
+    const ROUND_PRECISION = 3;
+
     /**
      * Gets the translation for a given key.
      *

--- a/Core/TransactionHandler.php
+++ b/Core/TransactionHandler.php
@@ -237,7 +237,11 @@ class TransactionHandler
             $fChildAmount = (float) $aResult->fields['childTransactionsTotalAmount'];
         }
 
-        return round(bcsub($fBaseAmount, $fChildAmount, Helper::BCSUB_SCALE), Helper::ROUND_PRECISION);
+        // for the rounding precision use either the value the merchant set for currency
+        // decimal precision or a fallback value
+        $iRoundPrecision = Helper::getCurrencyRoundPrecision($oTransaction->wdoxidee_ordertransactions__currency);
+
+        return round(bcsub($fBaseAmount, $fChildAmount, Helper::BCSUB_SCALE), $iRoundPrecision);
     }
 
     /**

--- a/Core/TransactionHandler.php
+++ b/Core/TransactionHandler.php
@@ -234,10 +234,10 @@ class TransactionHandler
         $aResult = $oDb->select($sDbQuery, $aQueryArgs);
 
         if ($aResult !== false && $aResult->count() > 0) {
-            $fChildAmount = $aResult->fields['childTransactionsTotalAmount'];
+            $fChildAmount = (float) $aResult->fields['childTransactionsTotalAmount'];
         }
 
-        return $fBaseAmount - $fChildAmount;
+        return round(bcsub($fBaseAmount, $fChildAmount, Helper::BCSUB_SCALE), Helper::ROUND_PRECISION);
     }
 
     /**

--- a/Tests/Unit/Core/HelperTest.php
+++ b/Tests/Unit/Core/HelperTest.php
@@ -228,4 +228,23 @@ class HelperTest extends OxidEsales\TestingLibrary\UnitTestCase
     {
         Helper::addToViewData(new DateTime(), []);
     }
+
+    /**
+     * @dataProvider testGetCurrencyRoundPrecisionProvider
+     */
+    public function testGetCurrencyRoundPrecision($sCurrencyName, $iExpectedPrecision)
+    {
+        $this->assertEquals(Helper::getCurrencyRoundPrecision($sCurrencyName), $iExpectedPrecision);
+    }
+
+    public function testGetCurrencyRoundPrecisionProvider()
+    {
+        return [
+            'EUR' => ['EUR', 2],
+            'CHF' => ['CHF', 2],
+            'USD' => ['USD', 2],
+            'non existing currency' => ['XXXXX', Helper::ROUND_PRECISION_FALLBACK],
+            'null' => [null, Helper::ROUND_PRECISION_FALLBACK],
+        ];
+    }
 }

--- a/Tests/Unit/Core/TransactionHandlerTest.php
+++ b/Tests/Unit/Core/TransactionHandlerTest.php
@@ -48,6 +48,8 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
                 'columns' => ['oxid', 'oxordernr', 'oxpaymenttype', 'wdoxidee_transactionid'],
                 'rows' => [
                     ['oxid 1', 2, 'wdpaypal', 'transaction 1'],
+                    ['oxid 2', 3, 'wdpaypal', 'transaction 5'],
+                    ['oxid 3', 4, 'wdpaypal', 'transaction 8'],
                 ]
             ],
             [
@@ -58,6 +60,13 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
                     ['transaction 2', 'oxid 1', 2, 'transaction 2', 'transaction 1', 'reserve', 'capture-authorization', 'success', 40, 'EUR'],
                     ['transaction 3', 'oxid 1', 2, 'transaction 3', 'transaction 1', 'reserve', 'capture-authorization', 'closed', 40, 'EUR'],
                     ['transaction 4', 'oxid 1', 2, 'transaction 4', 'transaction 3', 'reserve', 'refund-capture', 'closed', 40, 'EUR'],
+                    ['transaction 5', 'oxid 2', 3, 'transaction 5', null, 'pay', 'debit', 'success', 33.8, 'EUR'],
+                    ['transaction 6', 'oxid 2', 3, 'transaction 6', 'transaction 5', 'pay', 'refund-debit', 'closed', 20, 'EUR'],
+                    ['transaction 7', 'oxid 2', 3, 'transaction 7', 'transaction 5', 'pay', 'refund-debit', 'closed', 13.7, 'EUR'],
+                    ['transaction 8', 'oxid 3', 4, 'transaction 8', null, 'pay', 'debit', 'success', 33.8, 'EUR'],
+                    ['transaction 9', 'oxid 3', 4, 'transaction 9', 'transaction 8', 'pay', 'refund-debit', 'closed', 20, 'EUR'],
+                    ['transaction 10', 'oxid 3', 4, 'transaction 10', 'transaction 8', 'pay', 'refund-debit', 'closed', 13.7, 'EUR'],
+                    ['transaction 11', 'oxid 3', 4, 'transaction 11', 'transaction 8', 'pay', 'refund-debit', 'closed', 0.1, 'EUR'],
                 ]
             ],
         ];
@@ -131,6 +140,8 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
             'transaction 2' => ['transaction 2', 40],
             'transaction 3' => ['transaction 3', 0],
             'transaction 4' => ['transaction 4', 40],
+            'transaction 5' => ['transaction 5', 0.1],
+            'transaction 8' => ['transaction 8', 0],
         ];
     }
 }

--- a/Tests/Unit/Core/TransactionHandlerTest.php
+++ b/Tests/Unit/Core/TransactionHandlerTest.php
@@ -50,6 +50,9 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
                     ['oxid 1', 2, 'wdpaypal', 'transaction 1'],
                     ['oxid 2', 3, 'wdpaypal', 'transaction 5'],
                     ['oxid 3', 4, 'wdpaypal', 'transaction 8'],
+                    ['oxid 4', 5, 'wdpaypal', 'transaction 12'],
+                    ['oxid 5', 6, 'wdpaypal', 'transaction 17'],
+                    ['oxid 6', 7, 'wdpaypal', 'transaction 19'],
                 ]
             ],
             [
@@ -67,6 +70,18 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
                     ['transaction 9', 'oxid 3', 4, 'transaction 9', 'transaction 8', 'pay', 'refund-debit', 'closed', 20, 'EUR'],
                     ['transaction 10', 'oxid 3', 4, 'transaction 10', 'transaction 8', 'pay', 'refund-debit', 'closed', 13.7, 'EUR'],
                     ['transaction 11', 'oxid 3', 4, 'transaction 11', 'transaction 8', 'pay', 'refund-debit', 'closed', 0.1, 'EUR'],
+                    ['transaction 12', 'oxid 4', 5, 'transaction 12', null, 'pay', 'debit', 'success', 9999.99, 'EUR'],
+                    ['transaction 13', 'oxid 4', 5, 'transaction 13', 'transaction 12', 'pay', 'refund-debit', 'closed', 0.4, 'EUR'],
+                    ['transaction 14', 'oxid 4', 5, 'transaction 14', 'transaction 12', 'pay', 'refund-debit', 'closed', 0.5, 'EUR'],
+                    ['transaction 15', 'oxid 4', 5, 'transaction 15', 'transaction 12', 'pay', 'refund-debit', 'closed', 0.6, 'EUR'],
+                    ['transaction 16', 'oxid 4', 5, 'transaction 16', 'transaction 12', 'pay', 'refund-debit', 'closed', 0.78, 'EUR'],
+                    ['transaction 17', 'oxid 5', 6, 'transaction 17', null, 'pay', 'debit', 'success', 100, 'EUR'],
+                    ['transaction 18', 'oxid 5', 6, 'transaction 18', 'transaction 17', 'pay', 'refund-debit', 'closed', 0.999, 'EUR'],
+                    ['transaction 19', 'oxid 6', 7, 'transaction 19', null, 'pay', 'debit', 'success', 212000000.49, 'HUF'],
+                    ['transaction 20', 'oxid 6', 7, 'transaction 20', 'transaction 19', 'pay', 'refund-debit', 'closed', 45555.65, 'HUF'],
+                    ['transaction 21', 'oxid 6', 7, 'transaction 21', 'transaction 19', 'pay', 'refund-debit', 'closed', 97855.69, 'HUF'],
+                    ['transaction 22', 'oxid 6', 7, 'transaction 22', 'transaction 19', 'pay', 'refund-debit', 'closed', 7855.28, 'HUF'],
+                    ['transaction 23', 'oxid 6', 7, 'transaction 23', 'transaction 19', 'pay', 'refund-debit', 'closed', 85256.47, 'HUF'],
                 ]
             ],
         ];
@@ -142,6 +157,9 @@ class TransactionHandlerTest extends Wirecard\Test\WdUnitTestCase
             'transaction 4' => ['transaction 4', 40],
             'transaction 5' => ['transaction 5', 0.1],
             'transaction 8' => ['transaction 8', 0],
+            'transaction 12' => ['transaction 12', 9997.71],
+            'transaction 17' => ['transaction 17', 99.0],
+            'transaction 19' => ['transaction 19', 211763477.4],
         ];
     }
 }


### PR DESCRIPTION
### This PR

* improves the floating-point calculation for post-processing transactions by using `bcsub` and an epsilon value for comparison.

### Jira Links

* https://jira.parkside.at/browse/WDPD-144