### PR TITLE
WDPD-154: Prevent SEPA Mandate Button CSS Manipulation

### DIFF
--- a/Core/OrderHelper.php
+++ b/Core/OrderHelper.php
@@ -229,8 +229,7 @@ class OrderHelper
         }
 
         // set the custom payment error code and text and redirect back to the payment step of the checkout process
-        Registry::getSession()->setVariable(self::PAY_ERROR_VARIABLE, self::PAY_ERROR_ID);
-        Registry::getSession()->setVariable(self::PAY_ERROR_TEXT_VARIABLE, join('<br/>', $aErrorDescriptions));
+        self::setSessionPaymentError(join('<br/>', $aErrorDescriptions));
         $sRedirectUrl = Registry::getConfig()->getShopHomeUrl() . 'cl=payment';
 
         $oOrder->handleOrderState(Order::STATE_FAILED);
@@ -316,5 +315,19 @@ class OrderHelper
     {
         $sPageUrl = $oResponse->getRedirectUrl();
         return Registry::getUtils()->redirect($sPageUrl);
+    }
+
+    /**
+     * Sets a payment error text to the session.
+     * @param string $sText
+     *
+     * @since 1.1.0
+     */
+    public static function setSessionPaymentError($sText)
+    {
+        $oSession = Registry::getSession();
+
+        $oSession->setVariable(self::PAY_ERROR_VARIABLE, self::PAY_ERROR_ID);
+        $oSession->setVariable(self::PAY_ERROR_TEXT_VARIABLE, $sText);
     }
 }

--- a/Extend/Controller/OrderController.php
+++ b/Extend/Controller/OrderController.php
@@ -247,7 +247,7 @@ class OrderController extends OrderController_parent
 
             try {
                 $oPaymentMethod->onBeforeTransactionCreation();
-            } catch (StandardException $oException) {
+            } catch (Exception $oException) {
                 OrderHelper::setSessionPaymentError($oException->getMessage());
 
                 return 'payment';

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -308,4 +308,13 @@ abstract class PaymentMethod
         $oChildClass = get_called_class();
         return $oChildClass::$_bMerchantOnly;
     }
+
+    /**
+     * Function to be run before a transaction is generated for the payment method.
+     *
+     * @since 1.1.0
+     */
+    public function onBeforeTransactionCreation()
+    {
+    }
 }

--- a/Model/SepaDirectDebitPaymentMethod.php
+++ b/Model/SepaDirectDebitPaymentMethod.php
@@ -9,6 +9,9 @@
 
 namespace Wirecard\Oxid\Model;
 
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Exception\StandardException;
+
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
 use Wirecard\Oxid\Extend\Model\Payment;
@@ -256,5 +259,20 @@ class SepaDirectDebitPaymentMethod extends PaymentMethod
     private function _isRefundAction($sAction)
     {
         return $sAction === TransactionModel::ACTION_CREDIT;
+    }
+
+    /**
+     * @inheritdoc
+     * @throws StandardException
+     *
+     * @since 1.1.0
+     */
+    public function onBeforeTransactionCreation()
+    {
+        $oConfig = Registry::getConfig();
+
+        if (!$oConfig->getRequestParameter('wdsepadd_checkbox')) {
+            throw new StandardException('Mandate information was not accepted.');
+        }
     }
 }

--- a/Model/SepaDirectDebitPaymentMethod.php
+++ b/Model/SepaDirectDebitPaymentMethod.php
@@ -10,7 +10,7 @@
 namespace Wirecard\Oxid\Model;
 
 use OxidEsales\Eshop\Core\Registry;
-use OxidEsales\Eshop\Core\Exception\StandardException;
+use OxidEsales\Eshop\Core\Exception\InputException;
 
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
@@ -263,7 +263,7 @@ class SepaDirectDebitPaymentMethod extends PaymentMethod
 
     /**
      * @inheritdoc
-     * @throws StandardException
+     * @throws InputException
      *
      * @since 1.1.0
      */
@@ -272,7 +272,7 @@ class SepaDirectDebitPaymentMethod extends PaymentMethod
         $oConfig = Registry::getConfig();
 
         if (!$oConfig->getRequestParameter('wdsepadd_checkbox')) {
-            throw new StandardException('Mandate information was not accepted.');
+            throw new InputException('Mandate information was not accepted.');
         }
     }
 }

--- a/Tests/Unit/Core/OrderHelperTest.php
+++ b/Tests/Unit/Core/OrderHelperTest.php
@@ -214,4 +214,14 @@ class OrderHelperTest extends WdUnitTestCase
             'handle InteractionResponse' => [$oInteractionResponseStub, $sInteractionRedirect],
         ];
     }
+
+    public function testSetSessionPaymentError()
+    {
+        OrderHelper::setSessionPaymentError('foo');
+
+        $oSession = Registry::getSession();
+
+        $this->assertEquals($oSession->getVariable(OrderHelper::PAY_ERROR_VARIABLE), OrderHelper::PAY_ERROR_ID);
+        $this->assertEquals($oSession->getVariable(OrderHelper::PAY_ERROR_TEXT_VARIABLE), 'foo');
+    }
 }

--- a/views/blocks/checkout_errors.tpl
+++ b/views/blocks/checkout_errors.tpl
@@ -10,13 +10,13 @@
 [{$smarty.block.parent}]
 
 [{if $iPayError == -100}]
-    <div class="alert alert-danger">[{oxmultilang ident="wd_canceled_payment_process"}]</div>
+    <div class="alert alert-danger status error">[{oxmultilang ident="wd_canceled_payment_process"}]</div>
 [{/if}]
 
 [{if $iPayError == -101}]
-    <div class="alert alert-danger">[{oxmultilang ident="wd_order_error"}]</div>
+    <div class="alert alert-danger status error">[{oxmultilang ident="wd_order_error"}]</div>
 [{/if}]
 
 [{if $iPayError == -102}]
-    <div class="alert alert-danger">[{$oView->getPaymentErrorText()}]</div>
+    <div class="alert alert-danger status error">[{$oView->getPaymentErrorText()}]</div>
 [{/if}]

--- a/views/blocks/sepa_mandate_modal.tpl
+++ b/views/blocks/sepa_mandate_modal.tpl
@@ -14,10 +14,6 @@
 
     [{$sepamandate}]
 
-    <input type="checkbox" id="sepadd-checkbox" style="margin-right: 5px"/><label for="sepadd-checkbox">[{oxmultilang ident="wd_sepa_text_6"}]</label>
-
-    <hr>
-
     <form action="[{$oViewConf->getSslSelfLink()}]" method="post" id="orderConfirmAgbBottom" class="form-horizontal">
         <div class="hidden">
             [{$oViewConf->getHiddenSid()}]
@@ -35,6 +31,10 @@
             <input type="hidden" name="oxdownloadableproductsagreement" value="0">
             <input type="hidden" name="oxserviceproductsagreement" value="0">
         </div>
+
+        <input type="checkbox" name="wdsepadd_checkbox" id="sepadd-checkbox" style="margin-right: 5px"/><label for="sepadd-checkbox">[{oxmultilang ident="wd_sepa_text_6"}]</label>
+
+        <hr>
 
         [{block name="checkout_order_btn_submit_bottom"}]
           <button type="submit" disabled class="btn btn-primary submitButton nextStep">


### PR DESCRIPTION
### This PR

* Adds backend validation for SEPA Direct Debit payments to check whether or not the mandate accept checkbox was actually ticked
* Adds Unit tests to SEPA Direct Debit payment method
* Adds alert styles for the Azure theme

### Notes

* The error message "Mandate information was not accepted." is deliberately not translated, because it is only displayed to the user if he attempted to manipulate the SEPA form.

### How to Test

* Activate the _Wirecard SEPA Direct Debit_ method
* Go through the checkout process
* On the last step, click "Order now" to open the SEPA mandate popup
* Use your browser's developer tools to run the following command in the console (e.g. for Chrome, press `⎇⌘J`): `document.querySelector('.submitButton[disabled]').removeAttribute('disabled')`
* The "Accept" button should now be activated, even though the mandate accept checkbox was not ticked
* Click "Accept" and confirm that the payment is not processed but an error message is displayed

### Jira Links

* WDPD-154: https://jira.parkside.at/browse/WDPD-154