### PR TITLE
WDPD-165: Guaranteed Invoice by Wirecard Backend Countries

### DIFF
--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -434,7 +434,7 @@ class Helper
     public static function getCountries()
     {
         $oList = oxNew(CountryList::class);
-        $oList->loadActiveCountries();
+        $oList->loadActiveCountries(Registry::getLang()->getObjectTplLanguage());
 
         return $oList->getArray();
     }

--- a/Core/Helper.php
+++ b/Core/Helper.php
@@ -12,6 +12,7 @@ namespace Wirecard\Oxid\Core;
 use DateTime;
 use Exception;
 
+use OxidEsales\Eshop\Application\Model\CountryList;
 use OxidEsales\Eshop\Application\Model\Payment;
 use OxidEsales\Eshop\Application\Model\Shop;
 use OxidEsales\Eshop\Core\Exception\StandardException;
@@ -421,5 +422,20 @@ class Helper
         $oSession = Registry::getSession();
         $sSessionId = $oSession->getId();
         return md5($sSessionId . '_' . $iTimestamp);
+    }
+
+    /**
+     * Returns all countries currently enabled in the shop.
+     *
+     * @return array
+     *
+     * @since 1.2.0
+     */
+    public static function getCountries()
+    {
+        $oList = oxNew(CountryList::class);
+        $oList->loadActiveCountries();
+
+        return $oList->getArray();
     }
 }

--- a/Core/PaymentMethodHelper.php
+++ b/Core/PaymentMethodHelper.php
@@ -59,7 +59,7 @@ class PaymentMethodHelper
     }
 
     /**
-     * Return array for currency select options
+     * Returns an array of currency select options.
      *
      * @return array
      *
@@ -72,6 +72,25 @@ class PaymentMethodHelper
 
         foreach ($aCurrencies as $oCurrency) {
             $aOptions[$oCurrency->name] = $oCurrency->name;
+        }
+
+        return $aOptions;
+    }
+
+    /**
+     * Returns an array of country select options.
+     *
+     * @return array
+     *
+     * @since 1.2.0
+     */
+    public static function getCountryOptions()
+    {
+        $aCountries = Helper::getCountries();
+        $aOptions = [];
+
+        foreach ($aCountries as $oCountry) {
+            $aOptions[$oCountry->oxcountry__oxisoalpha2->value] = $oCountry->oxcountry__oxtitle->value;
         }
 
         return $aOptions;

--- a/Extend/Controller/Admin/PaymentCountry.php
+++ b/Extend/Controller/Admin/PaymentCountry.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\Oxid\Extend\Controller\Admin;
+
+use Wirecard\Oxid\Core\Helper;
+use Wirecard\Oxid\Model\RatepayInvoicePaymentMethod;
+
+/**
+ * Controls the view for the payment country tab.
+ *
+ * @since 1.2.0
+ */
+class PaymentCountry extends PaymentCountry_parent
+{
+    /**
+     * @inheritdoc
+     * @return string
+     *
+     * @since 1.2.0
+     */
+    public function render()
+    {
+        if (!$this->_allowCountryAssignment()) {
+            Helper::addToViewData($this, [
+                'readonly' => true,
+            ]);
+        }
+
+        return parent::render();
+    }
+
+    /**
+     * Checks if country assignment should be allowed for the current payment method.
+     *
+     * @return bool
+     *
+     * @since 1.2.0
+     */
+    protected function _allowCountryAssignment()
+    {
+        return !in_array($this->getEditObjectId(), [
+            RatepayInvoicePaymentMethod::getName(true),
+        ]);
+    }
+}

--- a/Model/RatepayInvoicePaymentMethod.php
+++ b/Model/RatepayInvoicePaymentMethod.php
@@ -171,7 +171,16 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
     {
         return array_merge(
             parent::getPublicFieldNames(),
-            ['descriptor', 'additionalInfo', 'deleteCanceledOrder', 'deleteFailedOrder']
+            [
+                'descriptor',
+                'additionalInfo',
+                'deleteCanceledOrder',
+                'deleteFailedOrder',
+                'allowedCurrencies',
+                'shippingCountries',
+                'billingCountries',
+                'billingShipping',
+            ]
         );
     }
 

--- a/Model/RatepayInvoicePaymentMethod.php
+++ b/Model/RatepayInvoicePaymentMethod.php
@@ -133,16 +133,16 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                 'type' => 'multiselect',
                 'field' => 'oxpayments__shipping_countries',
                 'options' => PaymentMethodHelper::getCountryOptions(),
-                'title' => Helper::translate('config_shipping_countries'),
-                'description' => Helper::translate('config_shipping_countries_desc'),
+                'title' => Helper::translate('wd_config_shipping_countries'),
+                'description' => Helper::translate('wd_config_shipping_countries_desc'),
                 'required' => true,
             ],
             'billingCountries' => [
                 'type' => 'multiselect',
                 'field' => 'oxpayments__billing_countries',
                 'options' => PaymentMethodHelper::getCountryOptions(),
-                'title' => Helper::translate('config_billing_countries'),
-                'description' => Helper::translate('config_billing_countries_desc'),
+                'title' => Helper::translate('wd_config_billing_countries'),
+                'description' => Helper::translate('wd_config_billing_countries_desc'),
                 'required' => true,
             ],
             'billingShipping' => [
@@ -152,8 +152,8 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                     '1' => Helper::translate('wd_yes'),
                     '0' => Helper::translate('wd_no'),
                 ],
-                'title' => Helper::translate('config_billing_shipping'),
-                'description' => Helper::translate('config_billing_shipping_desc'),
+                'title' => Helper::translate('wd_config_billing_shipping'),
+                'description' => Helper::translate('wd_config_billing_shipping_desc'),
             ],
         ];
 

--- a/Model/RatepayInvoicePaymentMethod.php
+++ b/Model/RatepayInvoicePaymentMethod.php
@@ -128,6 +128,30 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                 'title' => Helper::translate('wd_config_allowed_currencies'),
                 'description' => Helper::translate('wd_config_allowed_currencies_desc'),
             ],
+            'shippingCountries' => [
+                'type' => 'multiselect',
+                'field' => 'oxpayments__shipping_countries',
+                'options' => PaymentMethodHelper::getCountryOptions(),
+                'title' => Helper::translate('config_shipping_countries'),
+                'description' => Helper::translate('config_shipping_countries_desc'),
+            ],
+            'billingCountries' => [
+                'type' => 'multiselect',
+                'field' => 'oxpayments__billing_countries',
+                'options' => PaymentMethodHelper::getCountryOptions(),
+                'title' => Helper::translate('config_billing_countries'),
+                'description' => Helper::translate('config_billing_countries_desc'),
+            ],
+            'billingShipping' => [
+                'type' => 'select',
+                'field' => 'oxpayments__billing_shipping',
+                'options' => [
+                    '1' => Helper::translate('wd_yes'),
+                    '0' => Helper::translate('wd_no'),
+                ],
+                'title' => Helper::translate('config_billing_shipping'),
+                'description' => Helper::translate('config_billing_shipping_desc'),
+            ],
         ];
 
         return parent::getConfigFields() + $aAdditionalFields;
@@ -157,7 +181,12 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
      */
     public function getMetaDataFieldNames()
     {
-        return ['allowed_currencies'];
+        return [
+            'allowed_currencies',
+            'shipping_countries',
+            'billing_countries',
+            'billing_shipping',
+        ];
     }
 
     /**

--- a/Model/RatepayInvoicePaymentMethod.php
+++ b/Model/RatepayInvoicePaymentMethod.php
@@ -127,6 +127,7 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                 'options' => PaymentMethodHelper::getCurrencyOptions(),
                 'title' => Helper::translate('wd_config_allowed_currencies'),
                 'description' => Helper::translate('wd_config_allowed_currencies_desc'),
+                'required' => true,
             ],
             'shippingCountries' => [
                 'type' => 'multiselect',
@@ -134,6 +135,7 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                 'options' => PaymentMethodHelper::getCountryOptions(),
                 'title' => Helper::translate('config_shipping_countries'),
                 'description' => Helper::translate('config_shipping_countries_desc'),
+                'required' => true,
             ],
             'billingCountries' => [
                 'type' => 'multiselect',
@@ -141,6 +143,7 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
                 'options' => PaymentMethodHelper::getCountryOptions(),
                 'title' => Helper::translate('config_billing_countries'),
                 'description' => Helper::translate('config_billing_countries_desc'),
+                'required' => true,
             ],
             'billingShipping' => [
                 'type' => 'select',

--- a/Tests/Unit/Core/HelperTest.php
+++ b/Tests/Unit/Core/HelperTest.php
@@ -8,6 +8,7 @@
  *
  */
 
+use OxidEsales\Eshop\Application\Model\Country;
 use OxidEsales\Eshop\Application\Model\Payment;
 use OxidEsales\Eshop\Application\Model\Shop;
 use OxidEsales\Eshop\Core\Controller\BaseController;
@@ -289,5 +290,10 @@ class HelperTest extends OxidEsales\TestingLibrary\UnitTestCase
         $sToken = Helper::getUniqueToken();
         $sTokenTwo = Helper::getUniqueToken();
         $this->assertNotEquals($sToken, $sTokenTwo);
+    }
+
+    public function testGetCountries()
+    {
+        $this->assertContainsOnlyInstancesOf(Country::class, Helper::getCountries());
     }
 }

--- a/Tests/Unit/Core/PaymentMethodHelperTest.php
+++ b/Tests/Unit/Core/PaymentMethodHelperTest.php
@@ -15,17 +15,6 @@ use OxidEsales\Eshop\Application\Model\User;
 
 class PaymentMethodHelperTest extends OxidEsales\TestingLibrary\UnitTestCase
 {
-    /**
-     * @var PaymentMethodHelper
-     */
-    private $_oPaymentMethodHelper;
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->_oPaymentMethodHelper = new PaymentMethodHelper();
-    }
-
     public function testGetSepaMandateHtml()
     {
         $oBasketStub = $this->getMockBuilder(Basket::class)
@@ -39,8 +28,21 @@ class PaymentMethodHelperTest extends OxidEsales\TestingLibrary\UnitTestCase
         $aDynArray['iban'] = 'DE42512308000000060004';
         Registry::getSession()->setVariable('dynvalue', $aDynArray);
 
-        $sSepaMandate = $this->_oPaymentMethodHelper->getSepaMandateHtml($oBasketStub, $oUserStub);
+        $sSepaMandate = PaymentMethodHelper::getSepaMandateHtml($oBasketStub, $oUserStub);
         $this->assertContains('DE42512308000000060004', $sSepaMandate);
     }
 
+    public function testGetCurrencyOptions()
+    {
+        $aCurrencyOptions = PaymentMethodHelper::getCurrencyOptions();
+
+        $this->assertEquals(array_keys($aCurrencyOptions), array_values($aCurrencyOptions));
+    }
+
+    public function testGetCountryOptions()
+    {
+        $aCountryOptions = PaymentMethodHelper::getCountryOptions();
+
+        $this->assertNotEquals(array_keys($aCountryOptions), array_values($aCountryOptions));
+    }
 }

--- a/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
+++ b/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+use Wirecard\Oxid\Extend\Controller\Admin\PaymentCountry;
+
+class OrderListTest extends \OxidEsales\TestingLibrary\UnitTestCase
+{
+    /**
+     * @var PaymentCountry
+     */
+    private $oPaymentCountry;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->oPaymentCountry = oxNew(PaymentCountry::class);
+    }
+
+    /**
+     * @dataProvider renderProvider
+     */
+    public function testRender($sPaymentId, $bAllowCountryAssignment)
+    {
+        $_POST['oxid'] = $sPaymentId;
+
+        $this->oPaymentCountry->render();
+
+        $aViewData = $this->oPaymentCountry->getViewData();
+
+        if ($bAllowCountryAssignment) {
+            $this->assertArrayNotHasKey('readonly', $aViewData);
+        } else {
+            $this->assertArrayHasKey('readonly', $aViewData);
+        }
+    }
+
+    public function renderProvider()
+    {
+        return [
+            'allow country assignment' => [
+                'oxidpayadvance',
+                true,
+            ],
+            'disallow country assignment' => [
+                'wdratepay-invoice',
+                false,
+            ],
+        ];
+    }
+}

--- a/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
+++ b/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
@@ -28,7 +28,7 @@ class PaymentCountryTest extends \OxidEsales\TestingLibrary\UnitTestCase
      */
     public function testRender($sPaymentId, $bAllowCountryAssignment)
     {
-        $_POST['oxid'] = $sPaymentId;
+        $this->setRequestParameter('oxid', $sPaymentId);
 
         $this->oPaymentCountry->render();
 

--- a/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
+++ b/Tests/Unit/Extend/Controller/Admin/PaymentCountryTest.php
@@ -9,7 +9,7 @@
 
 use Wirecard\Oxid\Extend\Controller\Admin\PaymentCountry;
 
-class OrderListTest extends \OxidEsales\TestingLibrary\UnitTestCase
+class PaymentCountryTest extends \OxidEsales\TestingLibrary\UnitTestCase
 {
     /**
      * @var PaymentCountry

--- a/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
+++ b/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
@@ -71,27 +71,9 @@ class RatepayInvoicePaymentMethodTest extends OxidEsales\TestingLibrary\UnitTest
         $this->assertObjectHasAttribute('shipping', $oTransaction);
     }
 
-    /**
-     * @dataProvider configFieldsProvider
-     */
-    public function testGetConfigFields($sContainsKey)
+    public function testGetConfigFields()
     {
-        $aConfigFields = $this->_oPaymentMethod->getConfigFields();
-        $this->assertArrayHasKey($sContainsKey, $aConfigFields);
-    }
-
-    public function configFieldsProvider()
-    {
-        return [
-            "contains additionalInfo" => ['additionalInfo'],
-            "contains deleteCanceledOrder" => ['deleteCanceledOrder'],
-            "contains deleteFailedOrder" => ['deleteFailedOrder'],
-        ];
-    }
-
-    public function testGetConfigFieldsCount()
-    {
-        $aFieldKeys = array_keys($this->_oPaymentMethod->getConfigFields());
+        $aFields = $this->_oPaymentMethod->getConfigFields();
 
         $this->assertEquals([
             'apiUrl',
@@ -108,21 +90,25 @@ class RatepayInvoicePaymentMethodTest extends OxidEsales\TestingLibrary\UnitTest
             'shippingCountries',
             'billingCountries',
             'billingShipping',
-        ], $aFieldKeys);
+        ], array_keys($aFields));
     }
 
     public function testGetPublicFieldNames()
     {
-        $aPublicFields = $this->_oPaymentMethod->getPublicFieldNames();
-        $aExpected = [
+        $aFieldNames = $this->_oPaymentMethod->getPublicFieldNames();
+
+        $this->assertEquals([
             'apiUrl',
             'maid',
             'descriptor',
             'additionalInfo',
             'deleteCanceledOrder',
             'deleteFailedOrder',
-        ];
-        $this->assertEquals($aExpected, $aPublicFields, '', 0.0, 1, true);
+            'allowedCurrencies',
+            'shippingCountries',
+            'billingCountries',
+            'billingShipping',
+        ], $aFieldNames);
     }
 
     public function testGetMetaDataFieldNames()

--- a/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
+++ b/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
@@ -105,6 +105,9 @@ class RatepayInvoicePaymentMethodTest extends OxidEsales\TestingLibrary\UnitTest
             'deleteCanceledOrder',
             'deleteFailedOrder',
             'allowedCurrencies',
+            'shippingCountries',
+            'billingCountries',
+            'billingShipping',
         ], $aFieldKeys);
     }
 

--- a/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
+++ b/Tests/Unit/Model/RatepayInvoicePaymentMethodTest.php
@@ -124,4 +124,14 @@ class RatepayInvoicePaymentMethodTest extends OxidEsales\TestingLibrary\UnitTest
         ];
         $this->assertEquals($aExpected, $aPublicFields, '', 0.0, 1, true);
     }
+
+    public function testGetMetaDataFieldNames()
+    {
+        $this->assertEquals([
+            'allowed_currencies',
+            'shipping_countries',
+            'billing_countries',
+            'billing_shipping',
+        ], $this->_oPaymentMethod->getMetaDataFieldNames());
+    }
 }

--- a/default_payment_config.xml
+++ b/default_payment_config.xml
@@ -146,6 +146,15 @@
         <allowed_currencies>
             <currency>EUR</currency>
         </allowed_currencies>
+        <shipping_countries>
+            <country>AT</country>
+            <country>DE</country>
+        </shipping_countries>
+        <billing_countries>
+            <country>AT</country>
+            <country>DE</country>
+        </billing_countries>
+        <billing_shipping>1</billing_shipping>
     </payment>
     <payment>
         <oxid>wdgiropay</oxid>

--- a/metadata.php
+++ b/metadata.php
@@ -57,6 +57,8 @@ $aModule = [
             => \Wirecard\Oxid\Extend\Controller\Admin\OrderList::class,
         \OxidEsales\Eshop\Application\Controller\Admin\PaymentMain::class
             => \Wirecard\Oxid\Extend\Controller\Admin\PaymentMain::class,
+        \OxidEsales\Eshop\Application\Controller\Admin\PaymentCountry::class
+            => \Wirecard\Oxid\Extend\Controller\Admin\PaymentCountry::class,
         \OxidEsales\Eshop\Application\Model\Order::class
             => \Wirecard\Oxid\Extend\Model\Order::class,
         \OxidEsales\Eshop\Application\Controller\OrderController::class

--- a/views/admin/blocks/wd_admin_payment_main_form.tpl
+++ b/views/admin/blocks/wd_admin_payment_main_form.tpl
@@ -145,7 +145,14 @@
       [{oxmultilang ident="GENERAL_ACTIVE"}]
     </td>
     <td class="edittext">
-      <input class="edittext" type="checkbox" name="editval[oxpayments__oxactive]" value='1' [{if $edit->oxpayments__oxactive->value == 1}]checked[{/if}] [{$readonly}]>
+      <input
+        class="edittext"
+        type="checkbox"
+        name="editval[oxpayments__oxactive]"
+        value='1'
+        [{if $edit->oxpayments__oxactive->value == 1}]checked[{/if}]
+        [{$readonly}]
+      >
       [{oxinputhelp ident="HELP_GENERAL_ACTIVE"}]
     </td>
   </tr>
@@ -154,7 +161,15 @@
       [{oxmultilang ident="PAYMENT_MAIN_NAME"}]
     </td>
     <td class="edittext">
-      <input type="text" class="editinput" size="25" maxlength="[{$edit->oxpayments__oxdesc->fldmax_length}]" name="editval[oxpayments__oxdesc]" value="[{$edit->oxpayments__oxdesc->value}]" [{$readonly}]>
+      <input
+        type="text"
+        class="editinput"
+        size="25"
+        maxlength="[{$edit->oxpayments__oxdesc->fldmax_length}]"
+        name="editval[oxpayments__oxdesc]"
+        value="[{$edit->oxpayments__oxdesc->value}]"
+        [{$readonly}]
+      >
       [{oxinputhelp ident="HELP_PAYMENT_MAIN_NAME"}]
     </td>
   </tr>
@@ -171,31 +186,59 @@
       [{/if}]
       <td class="edittext" [{if $configField.colspan}]colspan="[{$configField.colspan}]"[{/if}]>
         [{if $configField.type === 'text'}]
-          <input id="[{$configKey}]" type="text" class="editinput" size="38"
-                 name="editval[[{$fieldName}]]" value="[{$edit->$fieldName->value}]"
-                 [{if $configField.onchange}]onchange="[{$configField.onchange}]"[{/if}]
-                 / >
+          <input
+            id="[{$configKey}]"
+            type="text"
+            class="editinput"
+            size="38"
+            name="editval[[{$fieldName}]]"
+            value="[{$edit->$fieldName->value}]"
+            [{if $configField.required}]required[{/if}]
+            [{if $configField.onchange}]onchange="[{$configField.onchange}]"[{/if}]
+          >
         [{/if}]
 
         [{if $configField.type === 'select'}]
-          <select name="editval[[{$fieldName}]]">
+          <select
+            name="editval[[{$fieldName}]]"
+            [{if $configField.required}]required[{/if}]
+          >
             [{foreach from=$configField.options key=optionKey item=optionValue}]
-              <option value="[{$optionKey}]" [{if $edit->$fieldName->value == $optionKey}]selected[{/if}]>[{$optionValue}]</option>
+              <option
+                value="[{$optionKey}]"
+                [{if $edit->$fieldName->value == $optionKey}]selected[{/if}]
+              >[{$optionValue}]</option>
             [{/foreach}]
           </select>
         [{/if}]
 
         [{if $configField.type === 'multiselect'}]
-          <select id="[{$configKey}]" name="editval[[{$fieldName}]][]" class="wd-multiselect" multiple>
+          <select
+            id="[{$configKey}]"
+            name="editval[[{$fieldName}]][]"
+            class="wd-multiselect"
+            multiple
+            [{if $configField.required}]required[{/if}]
+          >
             [{foreach from=$configField.options key=optionKey item=optionValue}]
-              <option value="[{$optionKey}]" [{if in_array($optionValue, $edit->$fieldName->value)}]selected[{/if}]>[{$optionValue}]</option>
+              <option
+                  value="[{$optionKey}]"
+                  [{if $edit->$fieldName->value && in_array($optionKey, $edit->$fieldName->value)}]selected[{/if}]
+              >[{$optionValue}]</option>
             [{/foreach}]
           </select>
         [{/if}]
 
         [{if $configField.type === 'textarea'}]
-          <textarea id="[{$configKey}]" class="editinput" rows="5" cols="37" name="editval[[{$fieldName}]]"
-            value="[{$edit->$fieldName->value}]">[{$edit->$fieldName->value}]</textarea>
+          <textarea
+            id="[{$configKey}]"
+            class="editinput"
+            rows="5"
+            cols="37"
+            name="editval[[{$fieldName}]]"
+            value="[{$edit->$fieldName->value}]"
+            [{if $configField.required}]required[{/if}]
+          >[{$edit->$fieldName->value}]</textarea>
         [{/if}]
 
         [{if $configField.type === 'link'}]


### PR DESCRIPTION
### This PR

* Adds the following settings to the **Guaranteed Invoice by Wirecard** payment method:
  * Allowed Shipping Countries
  * Allowed Billing Countries
  * Identical Billing/Shipping Address
* Disables native OXID country assignment for the **Guaranteed Invoice by Wirecard** payment method

### Notes

* The default value for shipping- and billing address should be Austria & Germany. This is only possible if the merchant has enabled these countries beforehand (see section "How to Test"). By default, only Germany is enabled.
* The database helper was added because the generic helper class became too big
* The new settings are not processed in the frontend yet

### How to Test

* Enable the module
* Go to _Master Settings_ → _Countries_ and enable some countries – make sure to also enable Austria
* Go to _Shop Settings_ → _Payment Methods_ and click on **Guaranteed Invoice by Wirecard**
* Confirm that there are settings for:
  * Allowed Shipping Countries (default: Austria & Germany)
  * Allowed Billing Countries (default: Austria & Germany)
  * Identical Billing/Shipping Address (default: Yes)
* Change the settings and, click "Save" and check if everything was saved correctly


### Jira Links

* WDPD-165: https://jira.parkside.at/browse/WDPD-165