### PR TITLE
WDPD-174: Guaranteed Invoice by Payolution Backend Countries

### DIFF
--- a/Extend/Controller/Admin/PaymentCountry.php
+++ b/Extend/Controller/Admin/PaymentCountry.php
@@ -11,6 +11,7 @@ namespace Wirecard\Oxid\Extend\Controller\Admin;
 
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Model\RatepayInvoicePaymentMethod;
+use Wirecard\Oxid\Model\PayolutionInvoicePaymentMethod;
 
 /**
  * Controls the view for the payment country tab.
@@ -47,6 +48,7 @@ class PaymentCountry extends PaymentCountry_parent
     {
         return !in_array($this->getEditObjectId(), [
             RatepayInvoicePaymentMethod::getName(true),
+            PayolutionInvoicePaymentMethod::getName(true),
         ]);
     }
 }

--- a/Model/PayolutionInvoicePaymentMethod.php
+++ b/Model/PayolutionInvoicePaymentMethod.php
@@ -150,7 +150,15 @@ class PayolutionInvoicePaymentMethod extends PaymentMethod
     {
         return array_merge(
             parent::getPublicFieldNames(),
-            ['descriptor', 'additionalInfo', 'deleteCanceledOrder', 'deleteFailedOrder']
+            [
+                'descriptor',
+                'additionalInfo',
+                'deleteCanceledOrder',
+                'deleteFailedOrder',
+                'shippingCountries',
+                'billingCountries',
+                'billingShipping',
+            ]
         );
     }
 
@@ -164,7 +172,6 @@ class PayolutionInvoicePaymentMethod extends PaymentMethod
     public function getMetaDataFieldNames()
     {
         return [
-            'allowed_currencies',
             'shipping_countries',
             'billing_countries',
             'billing_shipping',

--- a/Model/PayolutionInvoicePaymentMethod.php
+++ b/Model/PayolutionInvoicePaymentMethod.php
@@ -10,6 +10,7 @@
 namespace Wirecard\Oxid\Model;
 
 use Wirecard\Oxid\Core\Helper;
+use Wirecard\Oxid\Core\PaymentMethodHelper;
 use Wirecard\PaymentSdk\Config\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
 use Wirecard\PaymentSdk\Transaction\PayolutionInvoiceTransaction;
@@ -107,7 +108,34 @@ class PayolutionInvoicePaymentMethod extends PaymentMethod
                 'title' => Helper::translate('wd_config_delete_failure_order'),
                 'description' => Helper::translate('wd_config_delete_failure_order_desc'),
             ],
+            'shippingCountries' => [
+                'type' => 'multiselect',
+                'field' => 'oxpayments__shipping_countries',
+                'options' => PaymentMethodHelper::getCountryOptions(),
+                'title' => Helper::translate('wd_config_shipping_countries'),
+                'description' => Helper::translate('wd_config_shipping_countries_desc'),
+                'required' => true,
+            ],
+            'billingCountries' => [
+                'type' => 'multiselect',
+                'field' => 'oxpayments__billing_countries',
+                'options' => PaymentMethodHelper::getCountryOptions(),
+                'title' => Helper::translate('wd_config_billing_countries'),
+                'description' => Helper::translate('wd_config_billing_countries_desc'),
+                'required' => true,
+            ],
+            'billingShipping' => [
+                'type' => 'select',
+                'field' => 'oxpayments__billing_shipping',
+                'options' => [
+                    '1' => Helper::translate('wd_yes'),
+                    '0' => Helper::translate('wd_no'),
+                ],
+                'title' => Helper::translate('wd_config_billing_shipping'),
+                'description' => Helper::translate('wd_config_billing_shipping_desc'),
+            ],
         ];
+
         return parent::getConfigFields() + $aAdditionalFields;
     }
 
@@ -124,5 +152,22 @@ class PayolutionInvoicePaymentMethod extends PaymentMethod
             parent::getPublicFieldNames(),
             ['descriptor', 'additionalInfo', 'deleteCanceledOrder', 'deleteFailedOrder']
         );
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return array
+     *
+     * @since 1.2.0
+     */
+    public function getMetaDataFieldNames()
+    {
+        return [
+            'allowed_currencies',
+            'shipping_countries',
+            'billing_countries',
+            'billing_shipping',
+        ];
     }
 }

--- a/Tests/Unit/Model/PayolutionInvoicePaymentMethodTest.php
+++ b/Tests/Unit/Model/PayolutionInvoicePaymentMethodTest.php
@@ -36,38 +36,50 @@ class PayolutionInvoicePaymentMethodTest extends \Wirecard\Test\WdUnitTestCase
         $this->assertInstanceOf(PayolutionInvoiceTransaction::class, $oTransaction);
     }
 
-    /**
-     * @dataProvider getConfigFieldsProvider
-     */
-    public function testGetConfigFields($sContainsKey)
+    public function testGetConfigFields()
     {
-        $aConfigFields = $this->_oPaymentMethod->getConfigFields();
-        $this->assertArrayHasKey($sContainsKey, $aConfigFields);
-    }
+        $aFields = $this->_oPaymentMethod->getConfigFields();
 
-    public function getConfigFieldsProvider()
-    {
-        return [
-            "contains descriptor" => ['descriptor'],
-            "contains additionalInfo" => ['additionalInfo'],
-            "contains deleteCanceledOrder" => ['deleteCanceledOrder'],
-            "contains deleteFailedOrder" => ['deleteFailedOrder'],
-        ];
+        $this->assertEquals([
+            'apiUrl',
+            'httpUser',
+            'httpPassword',
+            'testCredentials',
+            'maid',
+            'secret',
+            'descriptor',
+            'additionalInfo',
+            'deleteCanceledOrder',
+            'deleteFailedOrder',
+            'shippingCountries',
+            'billingCountries',
+            'billingShipping',
+        ], array_keys($aFields));
     }
 
     public function testGetPublicFieldNames()
     {
-        $aPublicFieldNames = $this->_oPaymentMethod->getPublicFieldNames();
+        $aFieldNames = $this->_oPaymentMethod->getPublicFieldNames();
 
-        $aExpected = [
-            "apiUrl",
-            "maid",
-            "descriptor",
-            "additionalInfo",
-            "deleteCanceledOrder",
-            "deleteFailedOrder",
-        ];
+        $this->assertEquals([
+            'apiUrl',
+            'maid',
+            'descriptor',
+            'additionalInfo',
+            'deleteCanceledOrder',
+            'deleteFailedOrder',
+            'shippingCountries',
+            'billingCountries',
+            'billingShipping',
+        ], $aFieldNames);
+    }
 
-        $this->assertEquals($aExpected, $aPublicFieldNames);
+    public function testGetMetaDataFieldNames()
+    {
+        $this->assertEquals([
+            'shipping_countries',
+            'billing_countries',
+            'billing_shipping',
+        ], $this->_oPaymentMethod->getMetaDataFieldNames());
     }
 }

--- a/default_payment_config.xml
+++ b/default_payment_config.xml
@@ -48,6 +48,20 @@
         <wdoxidee_httppass>3!3013=D3fD8X7</wdoxidee_httppass>
         <wdoxidee_descriptor>1</wdoxidee_descriptor>
         <wdoxidee_additional_info>1</wdoxidee_additional_info>
+        <!-- meta fields -->
+        <shipping_countries>
+            <country>AT</country>
+            <country>DE</country>
+            <country>CH</country>
+            <country>NL</country>
+        </shipping_countries>
+        <billing_countries>
+            <country>AT</country>
+            <country>DE</country>
+            <country>CH</country>
+            <country>NL</country>
+        </billing_countries>
+        <billing_shipping>1</billing_shipping>
     </payment>
     <payment>
         <oxid>wdideal</oxid>


### PR DESCRIPTION
### This PR

* Adds the following settings to the **Guaranteed Invoice by Payolution** payment method:
  * Allowed Shipping Countries
  * Allowed Billing Countries
  * Identical Billing/Shipping Address
* Disables native OXID country assignment for the **Guaranteed Invoice by Payolution** payment method

### Notes

* The default value for shipping- and billing address should be Austria, Germany, Netherlands, Switzerland. This is only possible if the merchant has enabled these countries beforehand (see section "How to Test"). By default, only Germany is enabled.

### How to Test

* Enable the module
* Go to _Master Settings_ → _Countries_ and enable some countries – make sure to also enable Austria, Switzerland and the Netherlands
* Go to _Shop Settings_ → _Payment Methods_ and click on **Guaranteed Invoice by Payolution**
* Confirm that there are settings for:
  * Allowed Shipping Countries (default: Austria, Germany, Netherlands, Switzerland)
  * Allowed Billing Countries (default: Austria, Germany, Netherlands, Switzerland)
  * Identical Billing/Shipping Address (default: Yes)
* Change the settings and, click "Save" and check if everything was saved correctly

### Jira Links

* WDPD-174: https://jira.parkside.at/browse/WDPD-174