### PR TITLE
WDPD-42: Rename giropay payment method

### DIFF
--- a/Model/GiropayPaymentMethod.php
+++ b/Model/GiropayPaymentMethod.php
@@ -20,7 +20,7 @@ use Wirecard\PaymentSdk\Transaction\Transaction;
 use Wirecard\Oxid\Core\Helper;
 
 /**
- * Payment method implementation for Giropay.
+ * Payment method implementation for giropay.
  *
  * @since 1.2.0
  */

--- a/Tests/Acceptance/GiropayCheckoutTest.php
+++ b/Tests/Acceptance/GiropayCheckoutTest.php
@@ -12,7 +12,7 @@ namespace Wirecard\Oxid\Tests\Acceptance;
 use Wirecard\Oxid\Model\GiropayPaymentMethod;
 
 /**
- * Acceptance tests for the Giropay checkout flow.
+ * Acceptance tests for the giropay checkout flow.
  */
 class GiropayCheckoutTest extends CheckoutTestCase
 {

--- a/default_payment_config.xml
+++ b/default_payment_config.xml
@@ -134,8 +134,8 @@
         <oxid>wdgiropay</oxid>
         <oxactive>0</oxactive>
         <oxtoamount>10000</oxtoamount>
-        <oxdesc>Wirecard Giropay</oxdesc>
-        <oxdesc_1>Wirecard Giropay</oxdesc_1>
+        <oxdesc>Wirecard giropay</oxdesc>
+        <oxdesc_1>Wirecard giropay</oxdesc_1>
         <oxsort>33</oxsort>
         <wdoxidee_logo>giropay.png</wdoxidee_logo>
         <wdoxidee_transactionaction>pay</wdoxidee_transactionaction>


### PR DESCRIPTION
### This PR

* Renames giropay payment method from **G**iropay to **g**iropay

### How to Test

* Enable the module
* Go to _Shop Settings_ → _Payment Methods_
* Confirm that "Wirecard giropay" is written with a lowercase G

### Jira Links

* WDPD-42: https://jira.parkside.at/browse/WDPD-42