### PR TITLE
Update PayPal Selenium tests

### DIFF
--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -52,9 +52,17 @@ class PaypalCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.paypal.password'),
             $this->getConfig('payments.paypal.password')
         );
-        $this->clickAndWait($this->getLocator('external.paypal.login'), 30);
+        $this->clickAndWait($this->getLocator('external.paypal.login'), 3);
+
+        // there might be a confirmation step here
+        if ($this->isElementPresent($this->getLocator('external.paypal.login'))) {
+            $this->click($this->getLocator('external.paypal.login'));
+        }
+
+        $this->waitForElement($this->getLocator('external.paypal.nextStep'), 30);
         $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 3);
 
+        // there might be another confirmation step here
         if ($this->isElementPresent($this->getLocator('external.paypal.nextStep'))) {
             $this->click($this->getLocator('external.paypal.nextStep'));
         }


### PR DESCRIPTION
### This PR

* Updates Selenium tests for PayPal to incorporate the latest changes in its UI

### Notes

* PayPal seems to have some sort of A/B testing in their checkout screens, so sometimes the old version is displayed and sometimes the new one. This could not be pinned down to a specific metric (e.g. IP address or browser language), so the tests are designed to work in both cases.
* Requires https://github.com/wirecard/oxid-ee/pull/124 to be merged first

### How to Test

* Run `rake runtests_selenium` and check if the PayPal tests pass.