### PR TITLE
Restore default payment methods checkout

### DIFF
--- a/Core/PaymentMethodFactory.php
+++ b/Core/PaymentMethodFactory.php
@@ -9,7 +9,7 @@
 
 namespace Wirecard\Oxid\Core;
 
-use OxidEsales\Eshop\Core\Exception\StandardException;
+use OxidEsales\Eshop\Core\Exception\SystemComponentException;
 
 use Wirecard\Oxid\Model\CreditCardPaymentMethod;
 use Wirecard\Oxid\Model\GiropayPaymentMethod;
@@ -67,7 +67,7 @@ class PaymentMethodFactory
      * @param string $sPaymentMethodType
      *
      * @return PaymentMethod
-     * @throws StandardException if $sPaymentMethodType is not registered
+     * @throws SystemComponentException if $sPaymentMethodType is not registered
      *
      * @since 1.0.0
      */
@@ -79,6 +79,6 @@ class PaymentMethodFactory
             return new $aClasses[$sPaymentMethodType];
         }
 
-        throw new StandardException("payment type not registered: {$sPaymentMethodType}");
+        throw new SystemComponentException("payment type not registered: {$sPaymentMethodType}");
     }
 }

--- a/Extend/Controller/OrderController.php
+++ b/Extend/Controller/OrderController.php
@@ -17,7 +17,6 @@ use OxidEsales\Eshop\Core\Registry;
 
 use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\OrderHelper;
-use Wirecard\Oxid\Core\PaymentMethodFactory;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
 use Wirecard\Oxid\Extend\Model\Order;
 use Wirecard\Oxid\Extend\Model\Payment;
@@ -75,7 +74,7 @@ class OrderController extends OrderController_parent
     {
         parent::init();
 
-        $this->_onBeforeOrderCreation();
+        OrderHelper::onBeforeOrderCreation($this->getPayment());
 
         $oSession = Registry::getSession();
         $sWdPaymentRedirect = Registry::getRequest()->getRequestParameter('wdpayment');
@@ -112,34 +111,6 @@ class OrderController extends OrderController_parent
         }
 
         return true;
-    }
-
-    /**
-     * Runs the payment method's `onBeforeOrderCreation` callback and shows a potential error message to the user.
-     *
-     * @return null
-     *
-     * @since 1.2.0
-     */
-    private function _onBeforeOrderCreation()
-    {
-        $oSession = Registry::getSession();
-        $oPayment = $this->getPayment();
-
-        if (!$oPayment || !$oPayment->isCustomPaymentMethod()) {
-            return;
-        }
-
-        try {
-            $oPaymentMethod = PaymentMethodFactory::create($oSession->getBasket()->getPaymentId());
-            $oPaymentMethod->onBeforeOrderCreation();
-        } catch (Exception $oException) {
-            OrderHelper::setSessionPaymentError($oException->getMessage());
-
-            $sRedirectUrl = Registry::getConfig()->getShopHomeUrl() . 'cl=payment';
-
-            return Registry::getUtils()->redirect($sRedirectUrl);
-        }
     }
 
     /**

--- a/Extend/Model/Payment.php
+++ b/Extend/Model/Payment.php
@@ -14,7 +14,7 @@ use Wirecard\Oxid\Core\PaymentMethodFactory;
 use Wirecard\Oxid\Model\MetaDataModel;
 use Wirecard\Oxid\Model\PaymentMethod;
 
-use OxidEsales\Eshop\Core\Exception\StandardException;
+use OxidEsales\Eshop\Core\Exception\SystemComponentException;
 
 /**
  * Extends the Payment model.
@@ -61,7 +61,7 @@ class Payment extends Payment_parent
     {
         try {
             return PaymentMethodFactory::create($this->getId());
-        } catch (StandardException $oException) {
+        } catch (SystemComponentException $oException) {
             return null;
         }
     }

--- a/Tests/Acceptance/CashInAdvanceCheckoutTest.php
+++ b/Tests/Acceptance/CashInAdvanceCheckoutTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/oxid-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\Oxid\Tests\Acceptance;
+
+/**
+ * Acceptance tests for OXID's Cash In Advance checkout flow.
+ */
+class CashInAdvanceCheckoutTest extends CheckoutTestCase
+{
+    public function getPaymentMethodName()
+    {
+        return 'oxidpayadvance';
+    }
+
+    public function testCheckout()
+    {
+        $this->goThroughCheckout();
+
+        $this->assertPaymentSuccessful();
+    }
+}

--- a/Tests/Acceptance/CheckoutTestCase.php
+++ b/Tests/Acceptance/CheckoutTestCase.php
@@ -17,27 +17,20 @@ use Wirecard\Oxid\Model\Transaction;
 abstract class CheckoutTestCase extends BaseAcceptanceTestCase
 {
     /**
-     * @var Wirecard\Oxid\Model\PaymentMethod
-     */
-    protected $paymentMethod;
-
-    /**
      * @inheritdoc
      */
     protected function setUp()
     {
         parent::setUp();
 
-        $this->paymentMethod = $this->getPaymentMethod();
-
         $this->insertMockData();
         $this->activatePaymentMethod();
     }
 
     /**
-     * Payment method getter.
+     * Payment method name getter.
      */
-    abstract public function getPaymentMethod();
+    abstract public function getPaymentMethodName();
 
     /**
      * Activates the payment method.
@@ -45,7 +38,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     public function activatePaymentMethod()
     {
         $this->executeSql("UPDATE `oxpayments` SET `OXACTIVE` = '1'
-            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     /**
@@ -54,7 +47,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     public function setPaymentActionPurchase()
     {
         $this->executeSql("UPDATE `oxpayments` SET `WDOXIDEE_TRANSACTIONACTION` = '" . Transaction::ACTION_PAY .
-            "' WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            "' WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     /**
@@ -63,7 +56,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     public function setPaymentActionAuthorize()
     {
         $this->executeSql("UPDATE `oxpayments` SET `WDOXIDEE_TRANSACTIONACTION` = '" . Transaction::ACTION_RESERVE .
-            "' WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            "' WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     /**
@@ -129,7 +122,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->continueToNextStep();
 

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\CreditCardPaymentMethod;
  */
 class CreditCardCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new CreditCardPaymentMethod();
+        return CreditCardPaymentMethod::getName(true);
     }
 
     public function testCheckoutForPurchaseNonThreeD()
@@ -65,14 +65,14 @@ class CreditCardCheckoutTest extends CheckoutTestCase
     {
         $this->executeSql("UPDATE `oxpayments`
             SET `WDOXIDEE_MAID` = '', `WDOXIDEE_SECRET` = ''
-            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     private function forceNonThreeD()
     {
         $this->executeSql("UPDATE `oxpayments`
             SET `WDOXIDEE_THREE_D_MAID` = '', `WDOXIDEE_THREE_D_SECRET` = ''
-            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     public function goThroughCheckout()
@@ -90,7 +90,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->continueToNextStep();
 

--- a/Tests/Acceptance/EpsCheckoutTest.php
+++ b/Tests/Acceptance/EpsCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\EpsPaymentMethod;
  */
 class EpsCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new EpsPaymentMethod();
+        return EpsPaymentMethod::getName(true);
     }
 
     public function testCheckout()

--- a/Tests/Acceptance/GiropayCheckoutTest.php
+++ b/Tests/Acceptance/GiropayCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\GiropayPaymentMethod;
  */
 class GiropayCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new GiropayPaymentMethod();
+        return GiropayPaymentMethod::getName(true);
     }
 
     public function testCheckout()
@@ -45,7 +45,7 @@ class GiropayCheckoutTest extends CheckoutTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->type(
             $this->getLocator('external.giropay.bic'),

--- a/Tests/Acceptance/IdealCheckoutTest.php
+++ b/Tests/Acceptance/IdealCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\IdealPaymentMethod;
  */
 class IdealCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new IdealPaymentMethod();
+        return IdealPaymentMethod::getName(true);
     }
 
     public function testCheckout()
@@ -45,7 +45,7 @@ class IdealCheckoutTest extends CheckoutTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->select(
             $this->getLocator('external.ideal.bank'),

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\PaypalPaymentMethod;
  */
 class PaypalCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new PaypalPaymentMethod();
+        return PaypalPaymentMethod::getName(true);
     }
 
     public function testCheckoutForPurchase()

--- a/Tests/Acceptance/RatepayInvoiceCheckoutTest.php
+++ b/Tests/Acceptance/RatepayInvoiceCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\RatepayInvoicePaymentMethod;
  */
 class RatepayInvoiceCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new RatepayInvoicePaymentMethod();
+        return RatepayInvoicePaymentMethod::getName(true);
     }
 
     public function testCheckoutWithRequiredProfileData()
@@ -53,7 +53,7 @@ class RatepayInvoiceCheckoutTest extends CheckoutTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->type(
             $this->getLocator('external.ratepayInvoice.dateOfBirth'),

--- a/Tests/Acceptance/SepaDirectDebitCheckoutTest.php
+++ b/Tests/Acceptance/SepaDirectDebitCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\SepaDirectDebitPaymentMethod;
  */
 class SepaDirectDebitCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new SepaDirectDebitPaymentMethod();
+        return SepaDirectDebitPaymentMethod::getName(true);
     }
 
     public function testCheckoutForPurchase()
@@ -63,7 +63,7 @@ class SepaDirectDebitCheckoutTest extends CheckoutTestCase
     {
         $this->executeSql("UPDATE `oxpayments`
             SET `WDOXIDEE_BIC` = '1'
-            WHERE `OXID` = '{$this->paymentMethod::getName(true)}'");
+            WHERE `OXID` = '{$this->getPaymentMethodName()}'");
     }
 
     public function goThroughCheckout()
@@ -81,7 +81,7 @@ class SepaDirectDebitCheckoutTest extends CheckoutTestCase
         // Step 3: Pay
         $this->click(sprintf(
             $this->getLocator('checkout.paymentMethod'),
-            $this->paymentMethod::getName(true)
+            $this->getPaymentMethodName()
         ));
         $this->type(
             $this->getLocator('external.sepadd.accountHolder'),

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -16,9 +16,9 @@ use Wirecard\Oxid\Model\SofortPaymentMethod;
  */
 class SofortCheckoutTest extends CheckoutTestCase
 {
-    public function getPaymentMethod()
+    public function getPaymentMethodName()
     {
-        return new SofortPaymentMethod();
+        return SofortPaymentMethod::getName(true);
     }
 
     public function testCheckout()

--- a/Tests/Unit/Core/OrderHelperTest.php
+++ b/Tests/Unit/Core/OrderHelperTest.php
@@ -224,4 +224,29 @@ class OrderHelperTest extends WdUnitTestCase
         $this->assertEquals($oSession->getVariable(OrderHelper::PAY_ERROR_VARIABLE), OrderHelper::PAY_ERROR_ID);
         $this->assertEquals($oSession->getVariable(OrderHelper::PAY_ERROR_TEXT_VARIABLE), 'foo');
     }
+
+    /**
+     * @dataProvider onBeforeOrderCreationProvider
+     */
+    public function testOnBeforeOrderCreation($blExpected, $sPaymentId)
+    {
+        oxTestModules::addFunction(
+            'oxUtils',
+            'redirect',
+            '{}'
+        );
+
+        $oPayment = oxNew(Payment::class);
+        $oPayment->load($sPaymentId);
+
+        $this->assertEquals($blExpected, OrderHelper::onBeforeOrderCreation($oPayment));
+    }
+
+    public function onBeforeOrderCreationProvider()
+    {
+        return [
+            'foreign payment method' => [true, 'oxidpayadvance'],
+            'custom payment method' => [false, 'wdpaypal'],
+        ];
+    }
 }

--- a/Tests/Unit/Core/PaymentMethodFactoryTest.php
+++ b/Tests/Unit/Core/PaymentMethodFactoryTest.php
@@ -49,7 +49,7 @@ class PaymentMethodFactoryTest extends OxidEsales\TestingLibrary\UnitTestCase
     }
 
     /**
-     * @expectedException \OxidEsales\Eshop\Core\Exception\StandardException
+     * @expectedException \OxidEsales\Eshop\Core\Exception\SystemComponentException
      */
     public function testInvalidPaymentMethod()
     {


### PR DESCRIPTION
### This PR

* Resolves an issue that causes the checkout to be broken for default payment methods (i.e. non-Wirecard payment methods)
* Adds Selenium tests for one of OXID's default payments

### How to Test

* Activate the module
* Go through the checkout and select one of OXID's default payment methods, e.g. **Cash in advance**
* Check if the order can be placed without any errors