### PR TITLE
WDPD-182: Update identical billing & shipping address logic

### DIFF
--- a/Model/RatepayInvoicePaymentMethod.php
+++ b/Model/RatepayInvoicePaymentMethod.php
@@ -281,14 +281,12 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
     {
         $oSession = Registry::getSession();
         $oBasket = $oSession->getBasket();
-        $sBillingCountryId = SessionHelper::getBillingCountryId();
-        $sShippingCountryId = SessionHelper::getShippingCountryId() ?? $sBillingCountryId;
 
         // if basket amount is within range is checked by oxid, no need to handle that
         return $this->_checkDateOfBirth() &&
             $this->_areArticlesAllowed($oBasket->getBasketArticles(), $oBasket->getVouchers()) &&
             $this->_isCurrencyAllowed($oBasket->getBasketCurrency()) &&
-            $this->_areAddressesAllowed($sBillingCountryId, $sShippingCountryId);
+            $this->_areAddressesAllowed(SessionHelper::getBillingCountryId(), SessionHelper::getShippingCountryId());
     }
 
     /**
@@ -434,8 +432,8 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
     /**
      * Checks if given billing and shipping countries are allowed for this payment.
      *
-     * @param string $sBillingCountryId
-     * @param string $sShippingCountryId
+     * @param string      $sBillingCountryId
+     * @param string|null $sShippingCountryId
      *
      * @return bool
      *
@@ -448,7 +446,7 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
         $oShippingCountry = oxNew(Country::class);
 
         $oBillingCountry->load($sBillingCountryId);
-        $oShippingCountry->load($sShippingCountryId);
+        $oShippingCountry->load($sShippingCountryId ?? $sBillingCountryId);
 
         return in_array(
             $oBillingCountry->oxcountry__oxisoalpha2->value,
@@ -458,7 +456,7 @@ class RatepayInvoicePaymentMethod extends PaymentMethod
             $oPayment->oxpayments__shipping_countries->value ?? []
         ) && (
             !$oPayment->oxpayments__billing_shipping->value ||
-            $sBillingCountryId === $sShippingCountryId
+            !$sShippingCountryId
         );
     }
 }


### PR DESCRIPTION
### This PR

* Updates the logic by which the **Guaranteed Invoice by Wirecard** payment method is being displayed to the user

### Notes

* If the setting "Identical Billing/Shipping Address" is activated, the payment method is only displayed if the user ticked the "Use billing address for shipping" checkbox in the checkout
* This is the same logic OXID uses to check if billing and shipping address are the same

### How to Test

* Activate the **Guaranteed Invoice by Wirecard** payment method and make sure the setting for "Use billing address for shipping" is set to "Yes"
* Go through the checkout and confirm that the payment method is only shown if the user ticked the "Use billing address for shipping" in the "Address" step (note that there also other rules by which the payment method is displayed or not, see https://github.com/wirecard/oxid-ee/pull/127)

### Jira Links

* WDPD-182: https://jira.parkside.at/browse/WDPD-182