### PR TITLE
Improve Selenium tests stability

### DIFF
--- a/Tests/Acceptance/BaseAcceptanceTestCase.php
+++ b/Tests/Acceptance/BaseAcceptanceTestCase.php
@@ -31,6 +31,10 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Parses JSON from a file and returns it if it is valid.
+     *
+     * @param string $path
+     *
+     * @return array
      */
     private function getJsonFromFile($path)
     {
@@ -60,6 +64,7 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Do not fail tests on log messages.
+     *
      * @inheritdoc
      */
     protected function failOnLoggedExceptions()
@@ -68,8 +73,10 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Returns a value in an array by a path in dot notation (e.g. "a.b.c").
+     *
      * @param array $array
      * @param string $path
+     *
      * @return mixed
      */
     private function getArrayValueByPath($array, $path)
@@ -89,7 +96,9 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Returns a config value by path.
+     *
      * @param string $path
+     *
      * @return mixed
      */
     public function getConfig($path = null)
@@ -99,7 +108,9 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Returns a mock data value by path.
+     *
      * @param string $path
+     *
      * @return mixed
      */
     public function getMockData($path = null)
@@ -109,7 +120,9 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Returns a locator by path.
+     *
      * @param string $path
+     *
      * @return mixed
      */
     public function getLocator($path = null)
@@ -119,6 +132,7 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
     /**
      * Patches the select method by ignoring an event exception thrown in Selenium RC.
+     *
      * @see https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/8184
      * @inheritdoc
      */
@@ -133,5 +147,19 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
 
             $this->fireEvent($selector, 'change');
         }
+    }
+
+    /**
+     * Selects a frame by selector.
+     *
+     * @param string $selector
+     */
+    public function selectFrameBySelector($selector)
+    {
+        $element = $this->getElement($selector);
+        $elementName = $element->getAttribute('name');
+
+        $this->getMinkSession()->getDriver()->switchToIFrame($elementName);
+        $this->selectedFrame = $elementName;
     }
 }

--- a/Tests/Acceptance/BaseAcceptanceTestCase.php
+++ b/Tests/Acceptance/BaseAcceptanceTestCase.php
@@ -16,29 +16,32 @@ use Selenium\Exception;
  */
 abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\AcceptanceTestCase
 {
-    private $config;
-    private $locators;
-    private $mockData;
+    private $oConfig;
+    private $oLocators;
+    private $oMockData;
 
-    public function __construct($name = null, $data = [], $dataName = '')
+    /**
+     * @inheritdoc
+     */
+    public function __construct($sName = null, $aData = [], $sDataName = '')
     {
-        parent::__construct($name, $data, $dataName);
+        parent::__construct($sName, $aData, $sDataName);
 
-        $this->config = $this->getJsonFromFile(__DIR__ . '/inc/config.json');
-        $this->locators = $this->getJsonFromFile(__DIR__ . '/inc/locators.json');
-        $this->mockData = $this->getJsonFromFile(__DIR__ . '/inc/mock-data.json');
+        $this->oConfig = $this->getJsonFromFile(__DIR__ . '/inc/config.json');
+        $this->oLocators = $this->getJsonFromFile(__DIR__ . '/inc/locators.json');
+        $this->oMockData = $this->getJsonFromFile(__DIR__ . '/inc/mock-data.json');
     }
 
     /**
      * Parses JSON from a file and returns it if it is valid.
      *
-     * @param string $path
+     * @param string $sPath
      *
      * @return array
      */
-    private function getJsonFromFile($path)
+    private function getJsonFromFile($sPath)
     {
-        return json_decode(file_get_contents($path), true);
+        return json_decode(file_get_contents($sPath), true);
     }
 
     /**
@@ -74,60 +77,60 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
     /**
      * Returns a value in an array by a path in dot notation (e.g. "a.b.c").
      *
-     * @param array $array
-     * @param string $path
+     * @param array $aArray
+     * @param string $sPath
      *
      * @return mixed
      */
-    private function getArrayValueByPath($array, $path)
+    private function getArrayValueByPath($aArray, $sPath)
     {
-        $value = $array;
+        $mValue = $aArray;
 
-        foreach (explode('.', $path) as $pathPart) {
-            if (!isset($value[$pathPart])) {
+        foreach (explode('.', $sPath) as $sPathPart) {
+            if (!isset($mValue[$sPathPart])) {
                 return null;
             }
 
-            $value = $value[$pathPart];
+            $mValue = $mValue[$sPathPart];
         }
 
-        return $value;
+        return $mValue;
     }
 
     /**
      * Returns a config value by path.
      *
-     * @param string $path
+     * @param string $sPath
      *
      * @return mixed
      */
-    public function getConfig($path = null)
+    public function getConfig($sPath = null)
     {
-        return $path ? $this->getArrayValueByPath($this->config, $path) : $this->config;
+        return $sPath ? $this->getArrayValueByPath($this->oConfig, $sPath) : $this->oConfig;
     }
 
     /**
      * Returns a mock data value by path.
      *
-     * @param string $path
+     * @param string $sPath
      *
      * @return mixed
      */
-    public function getMockData($path = null)
+    public function getMockData($sPath = null)
     {
-        return $path ? $this->getArrayValueByPath($this->mockData, $path) : $this->mockData;
+        return $sPath ? $this->getArrayValueByPath($this->oMockData, $sPath) : $this->oMockData;
     }
 
     /**
      * Returns a locator by path.
      *
-     * @param string $path
+     * @param string $sPath
      *
      * @return mixed
      */
-    public function getLocator($path = null)
+    public function getLocator($sPath = null)
     {
-        return $path ? $this->getArrayValueByPath($this->locators, $path) : $this->locators;
+        return $sPath ? $this->getArrayValueByPath($this->oLocators, $sPath) : $this->oLocators;
     }
 
     /**
@@ -136,30 +139,30 @@ abstract class BaseAcceptanceTestCase extends \OxidEsales\TestingLibrary\Accepta
      * @see https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/8184
      * @inheritdoc
      */
-    public function select($selector, $optionSelector)
+    public function select($sSelector, $sOptionSelector)
     {
         try {
-            parent::select($selector, $optionSelector);
-        } catch (Exception $exception) {
-            if (strpos($exception->getMessage(), 'EventTarget.dispatchEvent') === false) {
-                throw $exception;
+            parent::select($sSelector, $sOptionSelector);
+        } catch (Exception $oException) {
+            if (strpos($oException->getMessage(), 'EventTarget.dispatchEvent') === false) {
+                throw $oException;
             }
 
-            $this->fireEvent($selector, 'change');
+            $this->fireEvent($sSelector, 'change');
         }
     }
 
     /**
      * Selects a frame by selector.
      *
-     * @param string $selector
+     * @param string $sSelector
      */
-    public function selectFrameBySelector($selector)
+    public function selectFrameBySelector($sSelector)
     {
-        $element = $this->getElement($selector);
-        $elementName = $element->getAttribute('name');
+        $oElement = $this->getElement($sSelector);
+        $sElementName = $oElement->getAttribute('name');
 
-        $this->getMinkSession()->getDriver()->switchToIFrame($elementName);
-        $this->selectedFrame = $elementName;
+        $this->getMinkSession()->getDriver()->switchToIFrame($sElementName);
+        $this->selectedFrame = $sElementName;
     }
 }

--- a/Tests/Acceptance/CheckoutTestCase.php
+++ b/Tests/Acceptance/CheckoutTestCase.php
@@ -19,12 +19,12 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     /**
      * @var integer
      */
-    const WAIT_TIME_INTERNAL = 10;
+    const WAIT_TIME_INTERNAL = 20;
 
     /**
      * @var integer
      */
-    const WAIT_TIME_EXTERNAL = 30;
+    const WAIT_TIME_EXTERNAL = 40;
 
     /**
      * @inheritdoc

--- a/Tests/Acceptance/CheckoutTestCase.php
+++ b/Tests/Acceptance/CheckoutTestCase.php
@@ -74,15 +74,15 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
      */
     public function insertMockData()
     {
-        foreach ($this->getMockData() as $table => $entries) {
-            foreach ($entries as $fields) {
-                $columns = '`' . implode('`, `', array_keys($fields)) . '`';
-                $valuesInsert = '\'' . implode('\', \'', array_values($fields)) . '\'';
-                $valuesUpdate = implode(', ', array_map(function ($column) {
-                    return "`{$column}`=VALUES(`{$column}`)";
-                }, array_keys($fields)));
+        foreach ($this->getMockData() as $sTableName => $aEntries) {
+            foreach ($aEntries as $oFields) {
+                $sColumns = '`' . implode('`, `', array_keys($oFields)) . '`';
+                $sValuesInsert = '\'' . implode('\', \'', array_values($oFields)) . '\'';
+                $sValuesUpdate = implode(', ', array_map(function ($sColumn) {
+                    return "`{$sColumn}`=VALUES(`{$sColumn}`)";
+                }, array_keys($oFields)));
 
-                $this->executeSql("INSERT INTO `{$table}` ({$columns}) VALUES ({$valuesInsert}) ON DUPLICATE KEY UPDATE {$valuesUpdate}");
+                $this->executeSql("INSERT INTO `{$sTableName}` ({$sColumns}) VALUES ({$sValuesInsert}) ON DUPLICATE KEY UPDATE {$sValuesUpdate}");
             }
         }
     }
@@ -92,10 +92,10 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
      */
     public function loginMockUserToFrontend()
     {
-        $userName = $this->getMockData('oxuser.0.OXUSERNAME');
-        $password = $userName; // username and password are equal for mock users
+        $sUserName = $this->getMockData('oxuser.0.OXUSERNAME');
+        $sPassword = $sUserName; // username and password are equal for mock users
 
-        $this->loginInFrontend($userName, $password);
+        $this->loginInFrontend($sUserName, $sPassword);
     }
 
     /**
@@ -109,9 +109,9 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     /**
      * Navigates to the next step in the checkout.
      */
-    public function continueToNextStep($seconds = self::WAIT_TIME_INTERNAL)
+    public function continueToNextStep($iSeconds = self::WAIT_TIME_INTERNAL)
     {
-        $this->clickAndWait($this->getLocator('checkout.nextStep'), $seconds);
+        $this->clickAndWait($this->getLocator('checkout.nextStep'), $iSeconds);
     }
 
     /**
@@ -143,32 +143,32 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     /**
      * Waits until the redirect process has finished.
      *
-     * @param int $seconds
+     * @param int $iSeconds
      */
-    public function waitForRedirectConfirmation($seconds = self::WAIT_TIME_EXTERNAL)
+    public function waitForRedirectConfirmation($iSeconds = self::WAIT_TIME_EXTERNAL)
     {
         // there might be an insecure certificate warning that needs to be dismissed
         $this->getMinkSession()->getDriver()->getBrowser()->keyPressNative('10');
 
-        if ($seconds > 0 && strpos($this->getLocation(), shopURL) !== 0) {
+        if ($iSeconds > 0 && strpos($this->getLocation(), shopURL) !== 0) {
             sleep(1);
-            $this->waitForRedirectConfirmation($seconds - 1);
+            $this->waitForRedirectConfirmation($iSeconds - 1);
         }
     }
 
     /**
      * Checks if the given URL is pointing to the "Thank you" page.
      *
-     * @param string $url
+     * @param string $sUrl
      *
      * @return bool
      */
-    public function isThankYouPage($url)
+    public function isThankYouPage($sUrl)
     {
-        $queryString = parse_url($url, PHP_URL_QUERY);
+        $sQueryString = parse_url($sUrl, PHP_URL_QUERY);
 
-        return strpos($url, $this->_getShopUrl()) === 0 &&
-            (!$queryString || strpos($queryString, 'cl=thankyou') !== false);
+        return strpos($sUrl, $this->_getShopUrl()) === 0 &&
+            (!$sQueryString || strpos($sQueryString, 'cl=thankyou') !== false);
     }
 
     /**

--- a/Tests/Acceptance/CheckoutTestCase.php
+++ b/Tests/Acceptance/CheckoutTestCase.php
@@ -17,6 +17,16 @@ use Wirecard\Oxid\Model\Transaction;
 abstract class CheckoutTestCase extends BaseAcceptanceTestCase
 {
     /**
+     * @var integer
+     */
+    const WAIT_TIME_INTERNAL = 10;
+
+    /**
+     * @var integer
+     */
+    const WAIT_TIME_EXTERNAL = 30;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -99,7 +109,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
     /**
      * Navigates to the next step in the checkout.
      */
-    public function continueToNextStep($seconds = 10)
+    public function continueToNextStep($seconds = self::WAIT_TIME_INTERNAL)
     {
         $this->clickAndWait($this->getLocator('checkout.nextStep'), $seconds);
     }
@@ -135,7 +145,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
      *
      * @param int $seconds
      */
-    public function waitForRedirectConfirmation($seconds = 30)
+    public function waitForRedirectConfirmation($seconds = self::WAIT_TIME_EXTERNAL)
     {
         // there might be an insecure certificate warning that needs to be dismissed
         $this->getMinkSession()->getDriver()->getBrowser()->keyPressNative('10');

--- a/Tests/Acceptance/CheckoutTestCase.php
+++ b/Tests/Acceptance/CheckoutTestCase.php
@@ -132,6 +132,7 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
 
     /**
      * Waits until the redirect process has finished.
+     *
      * @param int $seconds
      */
     public function waitForRedirectConfirmation($seconds = 30)
@@ -147,7 +148,9 @@ abstract class CheckoutTestCase extends BaseAcceptanceTestCase
 
     /**
      * Checks if the given URL is pointing to the "Thank you" page.
+     *
      * @param string $url
+     *
      * @return bool
      */
     public function isThankYouPage($url)

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -95,7 +95,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         $this->continueToNextStep();
 
         // Step 4: Order
-        $this->waitForItemAppear($this->getLocator('external.creditcard.frame'), 30);
+        $this->waitForItemAppear($this->getLocator('external.creditcard.frame'), self::WAIT_TIME_EXTERNAL);
         $this->selectFrameBySelector($this->getLocator('external.creditcard.frame'));
         $this->type(
             $this->getLocator('external.creditcard.firstName'),
@@ -128,7 +128,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.creditcard.password'), 30);
+        $this->waitForElement($this->getLocator('external.creditcard.password'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.creditcard.password'),
             $this->getConfig('payments.creditcard.password')

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -123,7 +123,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
             $this->getConfig('payments.creditcard.expiryYear')
         );
         $this->selectWindow(null);
-        $this->continueToNextStep();
+        $this->continueToNextStep(self::WAIT_TIME_EXTERNAL);
     }
 
     private function goThroughExternalFlow()

--- a/Tests/Acceptance/CreditCardCheckoutTest.php
+++ b/Tests/Acceptance/CreditCardCheckoutTest.php
@@ -95,12 +95,8 @@ class CreditCardCheckoutTest extends CheckoutTestCase
         $this->continueToNextStep();
 
         // Step 4: Order
-        $rootFrame = $this->getSelectedFrame();
-
-        $this->waitForElement($this->getLocator('external.creditcard.frame'), 30);
-        $this->selectFrame($this->getLocator('external.creditcard.frameId'));
-
-        $this->waitForElement($this->getLocator('external.creditcard.firstName'));
+        $this->waitForItemAppear($this->getLocator('external.creditcard.frame'), 30);
+        $this->selectFrameBySelector($this->getLocator('external.creditcard.frame'));
         $this->type(
             $this->getLocator('external.creditcard.firstName'),
             $this->getConfig('payments.creditcard.firstName')
@@ -126,8 +122,7 @@ class CreditCardCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.creditcard.expiryYear'),
             $this->getConfig('payments.creditcard.expiryYear')
         );
-
-        $this->selectFrame($rootFrame);
+        $this->selectWindow(null);
         $this->continueToNextStep();
     }
 

--- a/Tests/Acceptance/EpsCheckoutTest.php
+++ b/Tests/Acceptance/EpsCheckoutTest.php
@@ -37,23 +37,15 @@ class EpsCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.eps.bic'),
             $this->getConfig('payments.eps.bic')
         );
-        $this->clickAndWait($this->getLocator('external.eps.submitBic'));
-
-        $this->waitForElement($this->getLocator('external.eps.id'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitBic'), 30);
         $this->type(
             $this->getLocator('external.eps.id'),
             $this->getConfig('payments.eps.id')
         );
-
-        $this->waitForElement($this->getLocator('external.eps.submitLogin'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.submitLogin'));
-        $this->waitForElement($this->getLocator('external.eps.signPayment'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.signPayment'));
-        $this->waitForElement($this->getLocator('external.eps.finalize'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.finalize'));
-        $this->waitForElement($this->getLocator('external.eps.ok'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.ok'));
-        $this->waitForElement($this->getLocator('external.eps.goBackToOxid'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.goBackToOxid'));
+        $this->clickAndWait($this->getLocator('external.eps.submitLogin'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitSign'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitFinalize'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitConfirm'), 30);
+        $this->click($this->getLocator('external.eps.backToShop'));
     }
 }

--- a/Tests/Acceptance/EpsCheckoutTest.php
+++ b/Tests/Acceptance/EpsCheckoutTest.php
@@ -32,20 +32,20 @@ class EpsCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.eps.bic'), 30);
+        $this->waitForElement($this->getLocator('external.eps.bic'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.eps.bic'),
             $this->getConfig('payments.eps.bic')
         );
-        $this->clickAndWait($this->getLocator('external.eps.submitBic'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitBic'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.eps.id'),
             $this->getConfig('payments.eps.id')
         );
-        $this->clickAndWait($this->getLocator('external.eps.submitLogin'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.submitSign'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.submitFinalize'), 30);
-        $this->clickAndWait($this->getLocator('external.eps.submitConfirm'), 30);
+        $this->clickAndWait($this->getLocator('external.eps.submitLogin'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.eps.submitSign'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.eps.submitFinalize'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.eps.submitConfirm'), self::WAIT_TIME_EXTERNAL);
         $this->click($this->getLocator('external.eps.backToShop'));
     }
 }

--- a/Tests/Acceptance/GiropayCheckoutTest.php
+++ b/Tests/Acceptance/GiropayCheckoutTest.php
@@ -68,6 +68,6 @@ class GiropayCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.giropay.extensionSc'),
             $this->getConfig('payments.giropay.extensionSc')
         );
-        $this->clickAndWait($this->getLocator('external.giropay.nextStep'));
+        $this->click($this->getLocator('external.giropay.nextStep'));
     }
 }

--- a/Tests/Acceptance/GiropayCheckoutTest.php
+++ b/Tests/Acceptance/GiropayCheckoutTest.php
@@ -59,7 +59,7 @@ class GiropayCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.giropay.sc'), 30);
+        $this->waitForElement($this->getLocator('external.giropay.sc'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.giropay.sc'),
             $this->getConfig('payments.giropay.sc')

--- a/Tests/Acceptance/IdealCheckoutTest.php
+++ b/Tests/Acceptance/IdealCheckoutTest.php
@@ -60,6 +60,6 @@ class IdealCheckoutTest extends CheckoutTestCase
     private function goThroughExternalFlow()
     {
         $this->waitForElement($this->getLocator('external.ideal.nextStep'), self::WAIT_TIME_EXTERNAL);
-        $this->clickAndWait($this->getLocator('external.ideal.nextStep'));
+        $this->click($this->getLocator('external.ideal.nextStep'));
     }
 }

--- a/Tests/Acceptance/IdealCheckoutTest.php
+++ b/Tests/Acceptance/IdealCheckoutTest.php
@@ -59,7 +59,7 @@ class IdealCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.ideal.nextStep'), 30);
+        $this->waitForElement($this->getLocator('external.ideal.nextStep'), self::WAIT_TIME_EXTERNAL);
         $this->clickAndWait($this->getLocator('external.ideal.nextStep'));
     }
 }

--- a/Tests/Acceptance/IdealCheckoutTest.php
+++ b/Tests/Acceptance/IdealCheckoutTest.php
@@ -59,7 +59,7 @@ class IdealCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.ideal.confirmTransaction'), 30);
-        $this->clickAndWait($this->getLocator('external.ideal.confirmTransaction'));
+        $this->waitForElement($this->getLocator('external.ideal.nextStep'), 30);
+        $this->clickAndWait($this->getLocator('external.ideal.nextStep'));
     }
 }

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -48,21 +48,17 @@ class PaypalCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.paypal.email'),
             $this->getConfig('payments.paypal.email')
         );
+        $this->click($this->getLocator('external.paypal.login'));
+        $this->waitForItemAppear($this->getLocator('external.paypal.password'), 10);
         $this->type(
             $this->getLocator('external.paypal.password'),
             $this->getConfig('payments.paypal.password')
         );
-        $this->clickAndWait($this->getLocator('external.paypal.login'), 3);
+        $this->click($this->getLocator('external.paypal.login'));
+        $this->waitForElement($this->getLocator('external.paypal.nextStep'), 30);
+        $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 10);
 
         // there might be a confirmation step here
-        if ($this->isElementPresent($this->getLocator('external.paypal.login'))) {
-            $this->click($this->getLocator('external.paypal.login'));
-        }
-
-        $this->waitForElement($this->getLocator('external.paypal.nextStep'), 30);
-        $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 3);
-
-        // there might be another confirmation step here
         if ($this->isElementPresent($this->getLocator('external.paypal.nextStep'))) {
             $this->click($this->getLocator('external.paypal.nextStep'));
         }

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -16,6 +16,8 @@ use Wirecard\Oxid\Model\PaypalPaymentMethod;
  */
 class PaypalCheckoutTest extends CheckoutTestCase
 {
+    protected $retryTimes = 1;
+
     public function getPaymentMethodName()
     {
         return PaypalPaymentMethod::getName(true);

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -16,6 +16,7 @@ use Wirecard\Oxid\Model\PaypalPaymentMethod;
  */
 class PaypalCheckoutTest extends CheckoutTestCase
 {
+    // catch possible A/B tests
     protected $retryTimes = 1;
 
     public function getPaymentMethodName()
@@ -58,7 +59,7 @@ class PaypalCheckoutTest extends CheckoutTestCase
         );
         $this->click($this->getLocator('external.paypal.login'));
         $this->waitForElement($this->getLocator('external.paypal.nextStep'), 30);
-        $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 10);
+        $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 3);
 
         // there might be a confirmation step here
         if ($this->isElementPresent($this->getLocator('external.paypal.nextStep'))) {

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -16,7 +16,11 @@ use Wirecard\Oxid\Model\PaypalPaymentMethod;
  */
 class PaypalCheckoutTest extends CheckoutTestCase
 {
-    // catch possible A/B tests
+    /**
+     * Catch possible A/B tests
+     * 
+     * @inheritdoc
+     */
     protected $retryTimes = 1;
 
     public function getPaymentMethodName()

--- a/Tests/Acceptance/PaypalCheckoutTest.php
+++ b/Tests/Acceptance/PaypalCheckoutTest.php
@@ -46,19 +46,19 @@ class PaypalCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.paypal.email'), 30);
+        $this->waitForElement($this->getLocator('external.paypal.email'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.paypal.email'),
             $this->getConfig('payments.paypal.email')
         );
         $this->click($this->getLocator('external.paypal.login'));
-        $this->waitForItemAppear($this->getLocator('external.paypal.password'), 10);
+        $this->waitForItemAppear($this->getLocator('external.paypal.password'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.paypal.password'),
             $this->getConfig('payments.paypal.password')
         );
         $this->click($this->getLocator('external.paypal.login'));
-        $this->waitForElement($this->getLocator('external.paypal.nextStep'), 30);
+        $this->waitForElement($this->getLocator('external.paypal.nextStep'), self::WAIT_TIME_EXTERNAL);
         $this->clickAndWait($this->getLocator('external.paypal.nextStep'), 3);
 
         // there might be a confirmation step here

--- a/Tests/Acceptance/RatepayInvoiceCheckoutTest.php
+++ b/Tests/Acceptance/RatepayInvoiceCheckoutTest.php
@@ -66,7 +66,7 @@ class RatepayInvoiceCheckoutTest extends CheckoutTestCase
         $this->continueToNextStep();
 
         // Step 4: Order
-        $this->continueToNextStep();
+        $this->continueToNextStep(self::WAIT_TIME_EXTERNAL);
     }
 
     private function removeRequiredProfileData()

--- a/Tests/Acceptance/SepaDirectDebitCheckoutTest.php
+++ b/Tests/Acceptance/SepaDirectDebitCheckoutTest.php
@@ -106,6 +106,6 @@ class SepaDirectDebitCheckoutTest extends CheckoutTestCase
 
         // Step 4: Popover
         $this->click($this->getLocator('external.sepadd.terms'));
-        $this->clickAndWait($this->getLocator('external.sepadd.nextStep'));
+        $this->clickAndWait($this->getLocator('external.sepadd.nextStep'), self::WAIT_TIME_EXTERNAL);
     }
 }

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -32,7 +32,7 @@ class SofortCheckoutTest extends CheckoutTestCase
 
     private function goThroughExternalFlow()
     {
-        $this->waitForElement($this->getLocator('external.sofort.country'), 30);
+        $this->waitForElement($this->getLocator('external.sofort.country'), self::WAIT_TIME_EXTERNAL);
         $this->select(
             $this->getLocator('external.sofort.country'),
             $this->getConfig('payments.sofort.country')
@@ -44,7 +44,7 @@ class SofortCheckoutTest extends CheckoutTestCase
         );
         $this->fireEvent($this->getLocator('external.sofort.bank'), 'input');
         $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.userId'), 30);
+        $this->waitForElement($this->getLocator('external.sofort.userId'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.sofort.userId'),
             $this->getConfig('payments.sofort.userId')
@@ -54,10 +54,10 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getConfig('payments.sofort.password')
         );
         $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.account'), 30);
+        $this->waitForElement($this->getLocator('external.sofort.account'), self::WAIT_TIME_EXTERNAL);
         $this->click($this->getLocator('external.sofort.account'));
         $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.tan'), 30);
+        $this->waitForElement($this->getLocator('external.sofort.tan'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.sofort.tan'),
             $this->getConfig('payments.sofort.tan')

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -43,8 +43,7 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getConfig('payments.sofort.bank')
         );
         $this->fireEvent($this->getLocator('external.sofort.bank'), 'input');
-        $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.userId'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.sofort.nextStep'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.sofort.userId'),
             $this->getConfig('payments.sofort.userId')
@@ -53,11 +52,9 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.sofort.password'),
             $this->getConfig('payments.sofort.password')
         );
-        $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.account'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.sofort.nextStep'), self::WAIT_TIME_EXTERNAL);
         $this->click($this->getLocator('external.sofort.account'));
-        $this->click($this->getLocator('external.sofort.nextStep'));
-        $this->waitForElement($this->getLocator('external.sofort.tan'), self::WAIT_TIME_EXTERNAL);
+        $this->clickAndWait($this->getLocator('external.sofort.nextStep'), self::WAIT_TIME_EXTERNAL);
         $this->type(
             $this->getLocator('external.sofort.tan'),
             $this->getConfig('payments.sofort.tan')

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -43,7 +43,8 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getConfig('payments.sofort.bank')
         );
         $this->fireEvent($this->getLocator('external.sofort.bank'), 'input');
-        $this->clickAndWait($this->getLocator('external.sofort.nextStep'));
+        $this->click($this->getLocator('external.sofort.nextStep'));
+        $this->waitForElement($this->getLocator('external.sofort.userId'), 30);
         $this->type(
             $this->getLocator('external.sofort.userId'),
             $this->getConfig('payments.sofort.userId')
@@ -52,13 +53,15 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.sofort.password'),
             $this->getConfig('payments.sofort.password')
         );
-        $this->clickAndWait($this->getLocator('external.sofort.nextStep'));
+        $this->click($this->getLocator('external.sofort.nextStep'));
+        $this->waitForElement($this->getLocator('external.sofort.account'), 30);
         $this->click($this->getLocator('external.sofort.account'));
-        $this->clickAndWait($this->getLocator('external.sofort.nextStep'));
+        $this->click($this->getLocator('external.sofort.nextStep'));
+        $this->waitForElement($this->getLocator('external.sofort.tan'), 30);
         $this->type(
             $this->getLocator('external.sofort.tan'),
             $this->getConfig('payments.sofort.tan')
         );
-        $this->clickAndWait($this->getLocator('external.sofort.nextStep'));
+        $this->click($this->getLocator('external.sofort.nextStep'));
     }
 }

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -37,6 +37,7 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.sofort.country'),
             $this->getConfig('payments.sofort.country')
         );
+        // wait time is specified in ms for `waitForPageToLoad`
         $this->waitForPageToLoad(self::WAIT_TIME_EXTERNAL * 1000);
         $this->type(
             $this->getLocator('external.sofort.bank'),

--- a/Tests/Acceptance/SofortCheckoutTest.php
+++ b/Tests/Acceptance/SofortCheckoutTest.php
@@ -37,7 +37,7 @@ class SofortCheckoutTest extends CheckoutTestCase
             $this->getLocator('external.sofort.country'),
             $this->getConfig('payments.sofort.country')
         );
-        $this->waitForPageToLoad();
+        $this->waitForPageToLoad(self::WAIT_TIME_EXTERNAL * 1000);
         $this->type(
             $this->getLocator('external.sofort.bank'),
             $this->getConfig('payments.sofort.bank')

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -44,9 +44,8 @@
       "nextStep": "//input[@type='submit']"
     },
     "ideal": {
-      "bank": "//select[@class='form-control']",
-      "nextStep": "//form/button[contains(@class, 'nextStep')]",
-      "confirmTransaction": "//*[@id='data']/table/tbody/tr[2]/td/table/tbody/tr/td/table/tbody/tr/td/form/table/tbody/tr[3]/td[1]/input"
+      "bank": "//select[@name='dynvalue[bank]']",
+      "nextStep": "//input[@type='submit']"
     },
     "ratepayInvoice": {
       "dateOfBirth": "dateOfBirth",

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -54,13 +54,13 @@
     },
     "eps": {
       "bic": "bankname",
-      "submitBic": "selectionSubmit",
       "id": "verfNr",
+      "submitBic": "selectionSubmit",
       "submitLogin": "sbtnLogin",
-      "signPayment": "sbtnSign",
-      "finalize": "sbtnSignSingle",
-      "ok": "sbtnOk",
-      "goBackToOxid": "//*[@id='content']/div[4]/div/form/div[2]/input"
+      "submitSign": "sbtnSign",
+      "submitFinalize": "sbtnSignSingle",
+      "submitConfirm": "sbtnOk",
+      "backToShop": "//input[@name='back2Shop']"
     }
   }
 }

--- a/Tests/Acceptance/inc/locators.json
+++ b/Tests/Acceptance/inc/locators.json
@@ -12,7 +12,6 @@
     },
     "creditcard": {
       "frame": "//iframe[@class='wirecard-seamless-frame']",
-      "frameId": "2",
       "firstName": "first_name",
       "lastName": "last_name",
       "cardNumber": "account_number",


### PR DESCRIPTION
### This PR

* Improves overall stability of Selenium tests, most notably PayPal, Credit Card and Sofort.
* Increases stability for Selenium tests in slow network conditions
* Add retry functionality to PayPal tests to catch possible A/B tests

### Notes

* On very slow networks, PayPal sometimes redirects to the Dashboard instead of the payment flow

### How to Test

* Run `rake runtests_selenium` and check if all tests pass
* Optional: Throttle your network speed (e.g. by using [this tool](https://stackoverflow.com/questions/9659382/installing-apples-network-link-conditioner-tool)) and re-run the tests