### PR TITLE
WDPD-187 Set order state after non-success redirect

### DIFF
--- a/Core/OxidEeEvents.php
+++ b/Core/OxidEeEvents.php
@@ -421,5 +421,11 @@ class OxidEeEvents
         if (!$oDbMetaDataHandler->tableExists(self::PAYMENT_METADATA_TABLE)) {
             self::createPaymentMethodMetaDataTable();
         }
+
+        // adds new enum to orderState field
+        $sQuery = "ALTER TABLE " . self::ORDER_TABLE .
+            " MODIFY `WDOXIDEE_ORDERSTATE` enum('" . implode("','", Order::getStates()) . "') default '" .
+            Order::getStates()[0] . "' NOT NULL";
+        self::$_oDb->execute($sQuery);
     }
 }

--- a/Extend/Model/Order.php
+++ b/Extend/Model/Order.php
@@ -263,6 +263,7 @@ class Order extends Order_parent
             BackendService::TYPE_PROCESSING => Helper::translate('wd_order_status_purchased'),
             BackendService::TYPE_CANCELLED => Helper::translate('wd_order_status_cancelled'),
             BackendService::TYPE_REFUNDED => Helper::translate('wd_order_status_refunded'),
+            self::STATE_FAILED => Helper::translate('wd_order_status_failed'),
         ];
     }
 
@@ -500,6 +501,10 @@ class Order extends Order_parent
                 "Order `{$this->getId()}` could not be deleted as requested by the payment method config."
             );
         }
+        // Change order state if consumer cancelled the order, or if there was a payment error.
+        // This is done whenever consumer gets redirected back to a cancel or error redirect url.
+        $this->oxorder__wdoxidee_orderstate = new Field($sState);
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
### This PR

* Sets order state to "cancelled" or "failed" depending on if consumer was redirected to cancel or error redirect url after payment process.

### Notes

* PR contains many new translation keys, but only one ('wd_order_status_failed') is used in this PR. The other new keys are part of other PRs which were already added to PhraseApp.
* If consumer cancels *PayPal* payment during the payment process (by clicking on “Cancel and return to Wirecard Merchant’s Test Store”), the order status is set to “Cancelled”
* If consumer cancels *eps* payment during the payment process (by clicking on “Zahlung abbrechen”), the order status is set to “Failed”
* This is dependent on which redirect URL was used after the payment process (success, error, or cancel), and it can’t be influenced directly by the module.

### How to Test

* Activate a Wirecard payment method, e.g. _Wirecard PayPal_
* Try to make PayPal payment, but before paying, click on cancel button in order to get redirected to OXID shop without finishing the payment
* Go to _Administer Orders_ and check the status of the newest order (it should not be "pending" anymore, but "cancelled" or "failed")

### Jira Links

* https://jira.parkside.at/browse/WDPD-187