### PR TITLE
Use local path for getting payment method config xml file

### DIFF
--- a/Core/OxidEeEvents.php
+++ b/Core/OxidEeEvents.php
@@ -171,7 +171,7 @@ class OxidEeEvents
         $oLogger = Registry::getLogger();
         $oConfig = Registry::getConfig();
         $sShopBaseURL = $oConfig->getShopUrl();
-        $oXmldata = simplexml_load_file($sShopBaseURL . "modules/wirecard/paymentgateway/default_payment_config.xml");
+        $oXmldata = simplexml_load_file(dirname(__DIR__) . "/default_payment_config.xml");
 
         if (!$oXmldata) {
             $oLogger->error("default_payment_config.xml could not be loaded.");


### PR DESCRIPTION
### This PR

* Improves loading of default_payment_config.xml file. The file is now loaded via "local" path.

### How to Test

* Activate the module in admin panel.
* All the payment methods from default_payment_config.xml file should be shown in ``Shop Settings -> Payment Methods``