### PR TITLE
WDPD-190 Clear cache on module deactivation event

### DIFF
--- a/Core/OxidEeEvents.php
+++ b/Core/OxidEeEvents.php
@@ -341,7 +341,7 @@ class OxidEeEvents
 
         self::addPaymentMethods();
 
-        self::_clearCache();
+        self::_clearFileCache();
     }
 
     /**
@@ -353,15 +353,15 @@ class OxidEeEvents
     {
         self::$_oDb = DatabaseProvider::getDb();
         self::_disablePaymentMethods();
-        self::_clearCache();
+        self::_clearFileCache();
     }
 
     /**
-     * Clears cache
+     * Clears file cache
      *
      * @since 1.2.0
      */
-    private static function _clearCache()
+    private static function _clearFileCache()
     {
         $sTmpDir = getShopBasePath() . "/tmp/";
         $sSmartyDir = $sTmpDir . "smarty/";

--- a/Core/OxidEeEvents.php
+++ b/Core/OxidEeEvents.php
@@ -336,20 +336,9 @@ class OxidEeEvents
         self::_migrateFrom100To110();
         self::_migrateFrom110To120();
 
-        // view tables must be regenerated after modifying database table structure
-        Helper::regenerateViews();
-
         self::addPaymentMethods();
 
-        $sTmpDir = getShopBasePath() . "/tmp/";
-        $sSmartyDir = $sTmpDir . "smarty/";
-
-        foreach (glob($sTmpDir . "*.txt") as $sFileName) {
-            @unlink($sFileName);
-        }
-        foreach (glob($sSmartyDir . "*.php") as $sFileName) {
-            @unlink($sFileName);
-        }
+        self::_clearCache();
     }
 
     /**
@@ -361,6 +350,28 @@ class OxidEeEvents
     {
         self::$_oDb = DatabaseProvider::getDb();
         self::_disablePaymentMethods();
+        self::_clearCache();
+    }
+
+    /**
+     * Clears cache
+     *
+     * @since 1.2.0
+     */
+    private static function _clearCache()
+    {
+        // view tables must be regenerated after modifying database table structure
+        Helper::regenerateViews();
+
+        $sTmpDir = getShopBasePath() . "/tmp/";
+        $sSmartyDir = $sTmpDir . "smarty/";
+
+        foreach (glob($sTmpDir . "*.txt") as $sFileName) {
+            @unlink($sFileName);
+        }
+        foreach (glob($sSmartyDir . "*.php") as $sFileName) {
+            @unlink($sFileName);
+        }
     }
 
     /**

--- a/Core/OxidEeEvents.php
+++ b/Core/OxidEeEvents.php
@@ -336,6 +336,9 @@ class OxidEeEvents
         self::_migrateFrom100To110();
         self::_migrateFrom110To120();
 
+        // view tables must be regenerated after modifying database table structure
+        Helper::regenerateViews();
+
         self::addPaymentMethods();
 
         self::_clearCache();
@@ -360,9 +363,6 @@ class OxidEeEvents
      */
     private static function _clearCache()
     {
-        // view tables must be regenerated after modifying database table structure
-        Helper::regenerateViews();
-
         $sTmpDir = getShopBasePath() . "/tmp/";
         $sSmartyDir = $sTmpDir . "smarty/";
 


### PR DESCRIPTION
### This PR

* Clears the cache on module deactivation event. This is necessary for making the "Shop Settings -> Payment Methods" load properly after deactivating the module (Wirecard payment methods remain in the view, but they are disabled). 

### How to Test

* Activate the module
* Deactivate the module
* Go to "Shop Settings -> Payment Methods"
* The view should load correctly (no maintenance mode)

### Jira Links

* https://jira.parkside.at/browse/WDPD-190