### PR TITLE
WDPD-203 Checkout payment description position improvement

### DIFF
--- a/views/blocks/select_payment.tpl
+++ b/views/blocks/select_payment.tpl
@@ -56,20 +56,19 @@
                     </div>
                 </div>
             [{/foreach}]
+            [{block name="checkout_payment_longdesc"}]
+                [{if $paymentmethod->oxpayments__oxlongdesc->value}]
+                    <div class="row">
+                        <div class="col-xs-12 col-lg-9 col-lg-offset-3">
+                            <div class="alert alert-info desc">
+                                [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+                            </div>
+                        </div>
+                    </div>
+                [{/if}]
+            [{/block}]
         </dd>
     </dl>
-
-    [{block name="checkout_payment_longdesc"}]
-        [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-            <div class="row">
-                <div class="col-xs-12 col-lg-9 col-lg-offset-3">
-                    <div class="alert alert-info desc">
-                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                    </div>
-                </div>
-            </div>
-        [{/if}]
-    [{/block}]
 [{else}]
     [{$smarty.block.parent}]
 [{/if}]


### PR DESCRIPTION
### This PR

* Places checkout payment method description inside a non-collapsed box

### How to test

* Activate the module
* Activate any Wirecard's payment method which has checkout fields (for example SEPA Direct Debit)
* Configure payment description (it's a big textarea field on the right side on the payment configuration page)
* Try to create an order on frontend
* On third step (Payment) select Wirecard's payment method whose description was configured in admin panel previously
* Payment description will be shown in blue box within a non-collapsed payment method box

### Jira Ticket
https://jira.parkside.at/browse/WDPD-203