### PR TITLE
WDPD-225 Enable saving Payolution B2B configuration changes on admin page

### DIFF
--- a/Extend/Controller/Admin/PaymentMain.php
+++ b/Extend/Controller/Admin/PaymentMain.php
@@ -296,7 +296,7 @@ class PaymentMain extends PaymentMain_parent
         $sUser = $aParams['oxpayments__wdoxidee_httpuser'];
         $sPass = $aParams['oxpayments__wdoxidee_httppass'];
 
-        if ($aParams['oxpayments__oxid'] === PayolutionInvoicePaymentMethod::getName()) {
+        if ($this->_isPayolutionPaymentMethod($aParams['oxpayments__oxid'])) {
             // handle the case of different configuration per currency (currently only Payolution)
             // it's only checked if config values are entered on the frontend but no validation is done on the backend
             return $this->_checkCurrencyConfigFields($aParams);


### PR DESCRIPTION
### This PR

* Fixes issue with saving configuration of Payolution B2B payment method in admin panel.

### How to Test
* Go to Payolution B2B payment method configuration page in admin panel
* Enter valid configuration data and click on save button
* Configuration is saved successfully

### Jira Links
https://jira.parkside.at/browse/WDPD-225