### PR TITLE
WDPD-207 Improve Credit Card UX

### DIFF
--- a/Extend/Controller/Admin/PaymentMain.php
+++ b/Extend/Controller/Admin/PaymentMain.php
@@ -49,6 +49,13 @@ class PaymentMain extends PaymentMain_parent
     private $_bIsSavePossible;
 
     /**
+     * Stores the result of the credit card urls check.
+     *
+     * @since 1.3.0
+     */
+    private $_bCCUrlsValid = true;
+
+    /**
      * Tells if information about currency settings should be shown.
      * The information is shown any time merchant adds a currency which has empty configuration fields.
      *
@@ -76,6 +83,7 @@ class PaymentMain extends PaymentMain_parent
             // and an error message shown in the frontend
             Helper::addToViewData($this, [
                 'bConfigNotValid' => ($sFnc === 'save' || $sFnc === 'addfield') && !$this->_bIsSavePossible,
+                'bCCUrlsValid' => $this->_bCCUrlsValid,
                 'bShowCurrencyHelp' => $this->_bShowCurrencyHelp,
             ]);
         }
@@ -148,9 +156,11 @@ class PaymentMain extends PaymentMain_parent
      */
     private function _areCreditCardUrlsValid($aParams)
     {
-        return $aParams['oxpayments__oxid'] !== CreditCardPaymentMethod::getName()
+        $this->_bCCUrlsValid = $aParams['oxpayments__oxid'] !== CreditCardPaymentMethod::getName()
             || $this->_bothCreditCardUrlsAreTest($aParams)
             || $this->_noCreditCardUrlIsTest($aParams);
+
+        return $this->_bCCUrlsValid;
     }
 
     /**

--- a/Extend/Controller/Admin/PaymentMain.php
+++ b/Extend/Controller/Admin/PaymentMain.php
@@ -305,7 +305,12 @@ class PaymentMain extends PaymentMain_parent
         if ($this->_areCredentialsSet($sUrl, $sUser, $sPass)) {
             $oConfig = new Config($sUrl, $sUser, $sPass);
             $oTransactionService = $this->_getTransactionService($oConfig);
-            return $oTransactionService->checkCredentials();
+            try {
+                return $oTransactionService->checkCredentials();
+            } catch (\Exception $oException) {
+                Registry::getLogger()->error(__METHOD__ . ": Error checking credentials: " . $oException->getMessage());
+                return false;
+            }
         }
 
         return false;

--- a/Model/PaymentMethod/AlipayCrossBorderPaymentMethod.php
+++ b/Model/PaymentMethod/AlipayCrossBorderPaymentMethod.php
@@ -74,6 +74,7 @@ class AlipayCrossBorderPaymentMethod extends PaymentMethod
      */
     public function addMandatoryTransactionData(&$oTransaction, $oOrder)
     {
+        //TODO: once account holder is not needed by the sdk, remove this line
         $oTransaction->setAccountHolder($oOrder->getAccountHolder());
     }
 

--- a/out/js/wirecard_wdoxidee_credit_card_form.js
+++ b/out/js/wirecard_wdoxidee_credit_card_form.js
@@ -18,7 +18,7 @@ var ModuleCreditCardForm = (function($) {
   function callback() {
     $(".loader").fadeOut(200,function() {
       $("#creditcard-form-div")
-        .height(400)
+        .height(screen.width >= 992 ? 200 : 380)
         .fadeIn(200);
       getOrderButton().prop("disabled", false);
     });

--- a/out/js/wirecard_wdoxidee_credit_card_form.js
+++ b/out/js/wirecard_wdoxidee_credit_card_form.js
@@ -18,7 +18,7 @@ var ModuleCreditCardForm = (function($) {
   function callback() {
     $(".loader").fadeOut(200,function() {
       $("#creditcard-form-div")
-        .height(screen.width >= 992 ? 200 : 380)
+        .height(screen.width >= 992 ? 220 : 390)
         .fadeIn(200);
       getOrderButton().prop("disabled", false);
     });

--- a/translations/de/module_de_lang.php
+++ b/translations/de/module_de_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Für spätere Verwendung speichern.',
     'wd_vault_use_new_text' => 'Neue Kreditkarte verwenden',
     'wd_wait_for_final_status' => 'Bitte warten Sie auf ein zusätzliches E-Mail mit dem finalen Bezahlstatus.',
+    'wd_warning_credit_card_url_mismatch' => 'Achtung: Bitte überprüfen Sie Ihre Konfigurationsdaten in den URL-Eingabefeldern. Möglicherweise haben Sie ein Produktivkonto mit einem Testkonto kombiniert.',
     'wd_yes' => 'Ja',
 );

--- a/translations/en/module_en_lang.php
+++ b/translations/en/module_en_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Save for later use.',
     'wd_vault_use_new_text' => 'Use new credit card',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/translations/fr/module_fr_lang.php
+++ b/translations/fr/module_fr_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Enregistrer pour une utilisation ultérieure.',
     'wd_vault_use_new_text' => 'Utiliser une nouvelle carte de crédit',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Veuillez vérifier vos données de configuration dans les champs de saisie de l\'URL. Vous avez peut-être combiné un compte réel avec un compte d\'essai.',
     'wd_yes' => 'Yes',
 );

--- a/translations/id/module_id_lang.php
+++ b/translations/id/module_id_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Simpan untuk digunakan di kemudian hari.',
     'wd_vault_use_new_text' => 'Gunakan Kartu Kredit baru',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/translations/jp/module_jp_lang.php
+++ b/translations/jp/module_jp_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '後で使用するために保存する',
     'wd_vault_use_new_text' => '新しいクレジット カードを使用する',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/translations/kr/module_kr_lang.php
+++ b/translations/kr/module_kr_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '이후 사용을 위해 저장',
     'wd_vault_use_new_text' => '새 신용카드 사용',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/translations/zh_CN/module_zh_CN_lang.php
+++ b/translations/zh_CN/module_zh_CN_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '保存以备后用。',
     'wd_vault_use_new_text' => '使用新信用卡',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/translations/zh_TW/module_zh_TW_lang.php
+++ b/translations/zh_TW/module_zh_TW_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '儲存以備後用。',
     'wd_vault_use_new_text' => '使用新的信用卡',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/blocks/wd_admin_payment_main_form.tpl
+++ b/views/admin/blocks/wd_admin_payment_main_form.tpl
@@ -135,7 +135,11 @@
     <tr>
       <td colspan="2">
         <div class="wdoxidee-messagebox wdoxidee-messagebox--error">
-          [{oxmultilang ident="wd_error_save_failed"}]
+          [{if $paymentMethod->getName() === 'wdcreditcard'}]
+            [{oxmultilang ident="wd_warning_credit_card_url_mismatch"}]
+          [{else}]
+            [{oxmultilang ident="wd_error_save_failed"}]
+          [{/if}]
         </div>
       </td>
     </tr>

--- a/views/admin/blocks/wd_admin_payment_main_form.tpl
+++ b/views/admin/blocks/wd_admin_payment_main_form.tpl
@@ -135,10 +135,10 @@
     <tr>
       <td colspan="2">
         <div class="wdoxidee-messagebox wdoxidee-messagebox--error">
-          [{if $paymentMethod->getName() === 'wdcreditcard'}]
-            [{oxmultilang ident="wd_warning_credit_card_url_mismatch"}]
-          [{else}]
+          [{if $bCCUrlsValid}]
             [{oxmultilang ident="wd_error_save_failed"}]
+          [{else}]
+            [{oxmultilang ident="wd_warning_credit_card_url_mismatch"}]
           [{/if}]
         </div>
       </td>

--- a/views/admin/de/module_de_lang.php
+++ b/views/admin/de/module_de_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Für spätere Verwendung speichern.',
     'wd_vault_use_new_text' => 'Neue Kreditkarte verwenden',
     'wd_wait_for_final_status' => 'Bitte warten Sie auf ein zusätzliches E-Mail mit dem finalen Bezahlstatus.',
+    'wd_warning_credit_card_url_mismatch' => 'Achtung: Bitte überprüfen Sie Ihre Konfigurationsdaten in den URL-Eingabefeldern. Möglicherweise haben Sie ein Produktivkonto mit einem Testkonto kombiniert.',
     'wd_yes' => 'Ja',
 );

--- a/views/admin/en/module_en_lang.php
+++ b/views/admin/en/module_en_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Save for later use.',
     'wd_vault_use_new_text' => 'Use new credit card',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/fr/module_fr_lang.php
+++ b/views/admin/fr/module_fr_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Enregistrer pour une utilisation ultérieure.',
     'wd_vault_use_new_text' => 'Utiliser une nouvelle carte de crédit',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Veuillez vérifier vos données de configuration dans les champs de saisie de l\'URL. Vous avez peut-être combiné un compte réel avec un compte d\'essai.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/id/module_id_lang.php
+++ b/views/admin/id/module_id_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => 'Simpan untuk digunakan di kemudian hari.',
     'wd_vault_use_new_text' => 'Gunakan Kartu Kredit baru',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/jp/module_jp_lang.php
+++ b/views/admin/jp/module_jp_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '後で使用するために保存する',
     'wd_vault_use_new_text' => '新しいクレジット カードを使用する',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/kr/module_kr_lang.php
+++ b/views/admin/kr/module_kr_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '이후 사용을 위해 저장',
     'wd_vault_use_new_text' => '새 신용카드 사용',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/zh_CN/module_zh_CN_lang.php
+++ b/views/admin/zh_CN/module_zh_CN_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '保存以备后用。',
     'wd_vault_use_new_text' => '使用新信用卡',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );

--- a/views/admin/zh_TW/module_zh_TW_lang.php
+++ b/views/admin/zh_TW/module_zh_TW_lang.php
@@ -241,5 +241,6 @@ $aLang = array(
     'wd_vault_save_text' => '儲存以備後用。',
     'wd_vault_use_new_text' => '使用新的信用卡',
     'wd_wait_for_final_status' => 'Please, wait for additional email with the final status of your payment.',
+    'wd_warning_credit_card_url_mismatch' => 'Attention: Please check your credentials within the URL setting fields. You might have configured/combined a productive account with a test account.',
     'wd_yes' => 'Yes',
 );


### PR DESCRIPTION
### This PR
* Adds a TODO for Alipay 
* Adds the new string for cc config errors
* Improves cc iframe height for mobile & desktop

### Tests
* The bottom space of the credit card iframe should be the same for mobile and desktop
* Check the error messages for credit card and other payment methods after trying to save a invalid configuration, for credit cards the new string should appear, for all other payment methods nothing should change