### PR TITLE
WDPD-239 Change unmatched transactions handling

### DIFF
--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -479,14 +479,19 @@ class TransactionTabPostProcessing extends TransactionTab
     private function _getPaymentMethodConfig()
     {
         $oConfig = null;
-
         if (!is_null($this->_oTransaction)) {
             $sPaymentId = $this->_oTransaction->getPaymentType();
 
             if ($sPaymentId) {
                 $oPaymentMethod = PaymentMethodFactory::create($sPaymentId);
                 $oConfig = $oPaymentMethod->getConfig();
-            } else { // "wiretransfer"
+                return $oConfig;
+            }
+
+            // If sPaymentId is empty, it means transaction's order reference was empty.
+            // In that case, we have to confirm it was a POI/PIA transaction.
+            if ($this->_oTransaction->isPoiPiaPaymentMethod()) {
+                // Since POI and PIA payment methods share configuration, we create POI config.
                 $oPaymentMethod = PaymentMethodFactory::create("wdpaymentoninvoice");
                 $oConfig = $oPaymentMethod->getConfig();
             }

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -482,8 +482,14 @@ class TransactionTabPostProcessing extends TransactionTab
 
         if (!is_null($this->_oTransaction)) {
             $sPaymentId = $this->_oTransaction->getPaymentType();
-            $oPaymentMethod = PaymentMethodFactory::create($sPaymentId);
-            $oConfig = $oPaymentMethod->getConfig();
+
+            if ($sPaymentId) {
+                $oPaymentMethod = PaymentMethodFactory::create($sPaymentId);
+                $oConfig = $oPaymentMethod->getConfig();
+            } else { // "wiretransfer"
+                $oPaymentMethod = PaymentMethodFactory::create("wdpaymentoninvoice");
+                $oConfig = $oPaymentMethod->getConfig();
+            }
         }
 
         return $oConfig;

--- a/Controller/Admin/Transaction/TransactionTabPostProcessing.php
+++ b/Controller/Admin/Transaction/TransactionTabPostProcessing.php
@@ -18,8 +18,8 @@ use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\PaymentMethodFactory;
 use Wirecard\Oxid\Core\PostProcessingHelper;
 use Wirecard\Oxid\Core\TransactionHandler;
-use Wirecard\Oxid\Model\Transaction;
 use Wirecard\Oxid\Model\PaymentMethod\PaymentOnInvoicePaymentMethod;
+use Wirecard\Oxid\Model\Transaction;
 
 use Wirecard\PaymentSdk\BackendService;
 use Wirecard\PaymentSdk\Config\Config;

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -205,7 +205,7 @@ class NotifyHandler extends FrontendController
     }
 
     /**
-     * Saves transaction if it is unmatched and returns true. Otherwise returns false.
+     * Saves POI/PIA transaction if it is unmatched, and returns true. Otherwise returns false.
      *
      * @param string $sTransactionId
      * @param SuccessResponse $oResponse

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -197,7 +197,10 @@ class NotifyHandler extends FrontendController
         $oOrder = oxNew(Order::class);
         if ($this->_loadOrder($oOrder, $sTransactionId) >= self::MAX_TIMEOUT_SECONDS) {
             $this->_oLogger->error('No order found for transactionId: ' . $sTransactionId);
-            ResponseHandler::saveTransaction($oResponse, $oOrder, $oBackendService);
+            if ($oResponse->getPaymentMethod() === Transaction::WIRETRANSFER) { // unmatched POI/PIA transaction
+                // Unmatched transaction is saved only if it was a POI/PIA transaction
+                ResponseHandler::saveTransaction($oResponse, $oOrder, $oBackendService);
+            }
             return;
         }
 

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -197,7 +197,11 @@ class NotifyHandler extends FrontendController
 
         $oOrder = oxNew(Order::class);
         $bSavedTransaction = self::_saveIfUnmatchedPoiPiaTransaction(
-            $sTransactionId, $oResponse, $oBackendService, $oOrder);
+            $sTransactionId,
+            $oResponse,
+            $oBackendService,
+            $oOrder
+        );
 
         if (!$bSavedTransaction) {
             ResponseHandler::onSuccessResponse($oResponse, $oBackendService, $oOrder);

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -196,7 +196,8 @@ class NotifyHandler extends FrontendController
         }
 
         $oOrder = oxNew(Order::class);
-        $bSavedTransaction = self::_saveIfUnmatchedPoiPiaTransaction($sTransactionId, $oResponse, $oBackendService, $oOrder);
+        $bSavedTransaction = self::_saveIfUnmatchedPoiPiaTransaction(
+            $sTransactionId, $oResponse, $oBackendService, $oOrder);
 
         if (!$bSavedTransaction) {
             ResponseHandler::onSuccessResponse($oResponse, $oBackendService, $oOrder);
@@ -207,10 +208,10 @@ class NotifyHandler extends FrontendController
     /**
      * Saves POI/PIA transaction if it is unmatched, and returns true. Otherwise returns false.
      *
-     * @param string $sTransactionId
+     * @param string          $sTransactionId
      * @param SuccessResponse $oResponse
      * @param BackendService  $oBackendService
-     * @param Order $oOrder
+     * @param Order           $oOrder
      *
      * @return boolean
      *
@@ -226,7 +227,6 @@ class NotifyHandler extends FrontendController
                 ResponseHandler::saveTransaction($oResponse, $oOrder, $oBackendService);
                 return true;
             }
-
         }
         return false;
     }

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -207,7 +207,7 @@ class NotifyHandler extends FrontendController
     }
 
     /**
-     * Returns true if no matching order was found for transaction. Otherwise returns false.
+     * Handles transactions that cannot be matched to an existing order. Returns true if handled, false otherwise.
      *
      * @param string          $sTransactionId
      * @param SuccessResponse $oResponse

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -197,6 +197,7 @@ class NotifyHandler extends FrontendController
         $oOrder = oxNew(Order::class);
         if ($this->_loadOrder($oOrder, $sTransactionId) >= self::MAX_TIMEOUT_SECONDS) {
             $this->_oLogger->error('No order found for transactionId: ' . $sTransactionId);
+            ResponseHandler::saveTransaction($oResponse, $oOrder, $oBackendService);
             return;
         }
 

--- a/Controller/NotifyHandler.php
+++ b/Controller/NotifyHandler.php
@@ -21,8 +21,8 @@ use Psr\Log\LoggerInterface;
 use Wirecard\Oxid\Core\PaymentMethodFactory;
 use Wirecard\Oxid\Core\ResponseHandler;
 use Wirecard\Oxid\Extend\Model\Order;
-use Wirecard\Oxid\Model\PaymentMethod\CreditCardPaymentMethod;
 use Wirecard\Oxid\Model\PaymentMethod\BasePoiPiaPaymentMethod;
+use Wirecard\Oxid\Model\PaymentMethod\CreditCardPaymentMethod;
 use Wirecard\Oxid\Model\PaymentMethod\PaymentMethod;
 use Wirecard\Oxid\Model\Transaction;
 
@@ -221,7 +221,6 @@ class NotifyHandler extends FrontendController
     private function _handleUnmatchedTransactions($sTransactionId, $oResponse, $oBackendService, &$oOrder)
     {
         if ($this->_loadOrder($oOrder, $sTransactionId) >= self::MAX_TIMEOUT_SECONDS) {
-
             if ($oResponse->getPaymentMethod() === BasePoiPiaPaymentMethod::PAYMENT_METHOD_WIRETRANSFER) {
                 $this->_oLogger->info('Save unmatched order POI/PIA transaction: ' . $sTransactionId);
                 ResponseHandler::saveTransaction($oResponse, $oOrder, $oBackendService);

--- a/Core/ResponseHandler.php
+++ b/Core/ResponseHandler.php
@@ -52,7 +52,7 @@ class ResponseHandler
         //    $oLogger->warning('Transaction was possibly manipulated');
         //}
 
-        self::_saveTransaction($oResponse, $oOrder, $oBackendService);
+        self::saveTransaction($oResponse, $oOrder, $oBackendService);
 
         if (!self::_isPostProcessingAction($oResponse)) {
             self::_updateOrder($oOrder, $oResponse, $oBackendService);
@@ -122,7 +122,7 @@ class ResponseHandler
      *
      * @since 1.0.0
      */
-    private static function _saveTransaction($oResponse, $oOrder, $oBackendService)
+    public static function saveTransaction($oResponse, $oOrder, $oBackendService)
     {
         $aData = $oResponse->getData();
         $oUtilsDate = Registry::getUtilsDate();

--- a/Model/PaymentMethod/BasePoiPiaPaymentMethod.php
+++ b/Model/PaymentMethod/BasePoiPiaPaymentMethod.php
@@ -31,6 +31,8 @@ abstract class BasePoiPiaPaymentMethod extends SepaCreditTransferPaymentMethod
      */
     protected static $_bMerchantOnly = false;
 
+    const PAYMENT_METHOD_WIRETRANSFER = 'wiretransfer';
+
     /**
      * @inheritdoc
      *

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -17,6 +17,7 @@ use Wirecard\Oxid\Core\Helper;
 use Wirecard\Oxid\Core\OxidEeEvents;
 use Wirecard\Oxid\Core\PaymentMethodHelper;
 use Wirecard\Oxid\Core\ResponseMapper;
+use Wirecard\Oxid\Model\PaymentMethod\BasePoiPiaPaymentMethod;
 
 use Wirecard\PaymentSdk\Entity\Basket;
 
@@ -35,8 +36,6 @@ class Transaction extends MultiLanguageModel
     const STATE_SUCCESS = 'success';
     const STATE_CLOSED = 'closed';
     const STATE_ERROR = 'error';
-
-    const WIRETRANSFER = 'wiretransfer';
 
     /**
      * @inheritdoc
@@ -125,7 +124,7 @@ class Transaction extends MultiLanguageModel
     {
         $oXml = simplexml_load_string($this->getResponseXML());
         $sPaymentId = (string) $oXml->{'payment-methods'}->{'payment-method'}['name'];
-        return $sPaymentId === self::WIRETRANSFER;
+        return $sPaymentId === BasePoiPiaPaymentMethod::PAYMENT_METHOD_WIRETRANSFER;
     }
 
     /**

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -114,7 +114,7 @@ class Transaction extends MultiLanguageModel
     }
 
     /**
-     * Returns true if transaction's xml payment method is "wiretransfer"
+     * Returns true if transaction's xml payment method id is "wiretransfer"
      *
      * @return bool
      *
@@ -122,24 +122,24 @@ class Transaction extends MultiLanguageModel
      */
     public function isPoiPiaPaymentMethod()
     {
-        return self::_getTransactionXmlPaymentMethod() === BasePoiPiaPaymentMethod::PAYMENT_METHOD_WIRETRANSFER;
+        return self::_getTransactionXmlPaymentMethodId() === BasePoiPiaPaymentMethod::PAYMENT_METHOD_WIRETRANSFER;
     }
 
     /**
-     * Returns payment method from transaction xml object
+     * Returns payment method id from transaction xml object
      *
      * @return string
      *
      * @since 1.3.0
      */
-    private function _getTransactionXmlPaymentMethod()
+    private function _getTransactionXmlPaymentMethodId()
     {
         $oXml = simplexml_load_string($this->getResponseXML());
         return (string) $oXml->{'payment-methods'}->{'payment-method'}['name'];
     }
 
     /**
-     * Returns payment method name by transaction order reference if there is order reference.
+     * Returns payment method name from transaction order reference if existing.
      *
      * @return string|void
      *
@@ -163,9 +163,9 @@ class Transaction extends MultiLanguageModel
      *
      * @since 1.3.0
      */
-    private function _getPaymentMethodNameFromTransactionXmlPaymentMethod()
+    private function _getPaymentMethodNameFromTransactionXml()
     {
-        $sPaymentId = self::_getTransactionXmlPaymentMethod();
+        $sPaymentId = self::_getTransactionXmlPaymentMethodId();
         $oPayment = PaymentMethodHelper::getPaymentById('wd' . $sPaymentId);
 
         if (!$oPayment->oxpayments__oxid->value) {
@@ -203,7 +203,7 @@ class Transaction extends MultiLanguageModel
             return $sPaymentMethodName;
         }
 
-        return self::_getPaymentMethodNameFromTransactionXmlPaymentMethod();
+        return self::_getPaymentMethodNameFromTransactionXml();
     }
 
 

--- a/Tests/Integration/Model/TransactionTest.php
+++ b/Tests/Integration/Model/TransactionTest.php
@@ -47,6 +47,7 @@ class TransactionTest extends Wirecard\Test\WdUnitTestCase
                     ['6', 'order 1', 't4', null, '', 'success'],
                     ['7', 'order 2', 't5', null, '', 'awaiting'],
                     ['8', 'order 3', 't6', null, '', 'xxx'],
+                    ['9', null, 't7', null, '', 'xxx'],
                 ],
             ],
         ];
@@ -119,4 +120,24 @@ class TransactionTest extends Wirecard\Test\WdUnitTestCase
             'no translation found' => ['', 't6'],
         ];
     }
+
+    /**
+     * @dataProvider getTransactionPaymentMethodNameProvider
+     */
+    public function testGetTransactionPaymentMethodName($sExpected, $sTransactionId)
+    {
+        $oTransaction = oxNew(Transaction::class);
+        $oTransaction->loadWithTransactionId($sTransactionId);
+
+        $this->assertEquals($sExpected, $oTransaction->getTransactionPaymentMethodName());
+    }
+
+    public function getTransactionPaymentMethodNameProvider()
+    {
+        return [
+            'transaction with order id' => ['Wirecard Vorauskasse', 't4'],
+            'transaction without order id' => ['', 't7'],
+        ];
+    }
+
 }

--- a/views/admin/tpl/transaction_list.tpl
+++ b/views/admin/tpl/transaction_list.tpl
@@ -167,7 +167,7 @@ window.onload = function ()
                     <td class="[{$listclass}]">
                         <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">
                         [{$listitem->getTranslatedState()}]
-                          [{if $listitem->isPoiPiaPaymentMethod() && !$listitem->wdoxidee_ordertransactions__ordernumber->value}]
+                          [{if $listitem->isPoiPiaPaymentMethod() && !$ordernumber}]
                               ([{oxmultilang ident="wd_unmatched"}])
                           [{/if}]
                         </a>

--- a/views/admin/tpl/transaction_list.tpl
+++ b/views/admin/tpl/transaction_list.tpl
@@ -132,7 +132,6 @@ window.onload = function ()
             <tr>
                 [{block name="admin_transaction_list_item"}]
                     [{assign var="order" value=$listitem->getTransactionOrder()}]
-                    [{assign var="payment" value=$order->getOrderPayment()}]
                     [{if $listitem->getId() == $oxid}]
                         [{assign var="listclass" value=listitem4}]
                     [{else}]
@@ -145,7 +144,11 @@ window.onload = function ()
                         <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$listitem->wdoxidee_ordertransactions__orderid->value}]</a>
                     </td>
                     <td class="[{$listclass}]">
-                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$listitem->wdoxidee_ordertransactions__ordernumber->value}]</a>
+                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">
+                        [{if $listitem->wdoxidee_ordertransactions__ordernumber->value}]
+                          [{$listitem->wdoxidee_ordertransactions__ordernumber->value}]
+                        [{/if}]
+                        </a>
                     </td>
                     <td class="[{$listclass}]">
                         <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$listitem->wdoxidee_ordertransactions__transactionid->value}]</a>
@@ -157,11 +160,14 @@ window.onload = function ()
                         <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$listitem->wdoxidee_ordertransactions__type->value}]</a>
                     </td>
                     <td class="[{$listclass}]">
-                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$payment->oxpayments__oxdesc->value}]</a>
+                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">
+                        [{$listitem->getTransactionPaymentMethodName()}]
+                        </a>
                     </td>
                     <td class="[{$listclass}]">
-                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">[{$listitem->getTranslatedState()}]
-                          [{if $listitem->isPoiPiaPaymentMethod() && !$listitem->wdoxidee_ordertransactions__parenttransactionid->value}]
+                        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">
+                        [{$listitem->getTranslatedState()}]
+                          [{if $listitem->isPoiPiaPaymentMethod() && !$listitem->wdoxidee_ordertransactions__ordernumber->value}]
                               ([{oxmultilang ident="wd_unmatched"}])
                           [{/if}]
                         </a>

--- a/views/admin/tpl/transaction_list.tpl
+++ b/views/admin/tpl/transaction_list.tpl
@@ -131,7 +131,7 @@ window.onload = function ()
             [{foreach from=$mylist item=listitem}]
             <tr>
                 [{block name="admin_transaction_list_item"}]
-                    [{assign var="order" value=$listitem->getTransactionOrder()}]
+                    [{assign var="ordernumber" value=$listitem->wdoxidee_ordertransactions__ordernumber->value}]
                     [{if $listitem->getId() == $oxid}]
                         [{assign var="listclass" value=listitem4}]
                     [{else}]
@@ -145,8 +145,8 @@ window.onload = function ()
                     </td>
                     <td class="[{$listclass}]">
                         <a href="Javascript:top.oxid.admin.editThis('[{$listitem->wdoxidee_ordertransactions__oxid->value}]');">
-                        [{if $listitem->wdoxidee_ordertransactions__ordernumber->value}]
-                          [{$listitem->wdoxidee_ordertransactions__ordernumber->value}]
+                        [{if $ordernumber}]
+                          [{$ordernumber}]
                         [{/if}]
                         </a>
                     </td>


### PR DESCRIPTION
### This PR
* Adds POI/PIA transaction which comes via notification, even if it does not correspond to any order
* POI/PIA transactions without order reference are marked as unmatched

### How to Test
* Make a payment using POI or PIA payment method (optionally)
* Fake deposit transaction via Postman (use last example from [here](https://doc.wirecard.com/API_POIPIA.html#API_POIPIA_Samples): it is enough to use any random transaction id, which does not already exist in order database)
* In admin panel, go to ```Wirecard Transactions -> Transactions```
* Unmatched transactions are labeled like that in "Transaction state" column

### Notes
* It is assumed that POI/PIA payment methods are called "wiretransfer" inside deposit notification

### Jira Ticket
https://jira.parkside.at/browse/WDPD-239