### PR TITLE
WDPD-240 Hide Sepa Direct Debit modal on order page

### DIFF
--- a/views/blocks/order_button.tpl
+++ b/views/blocks/order_button.tpl
@@ -1,6 +1,12 @@
 [{oxstyle include=$oViewConf->getPaymentGatewayUrl("out/css/wirecard_wdoxidee_modal.css")}]
 [{oxscript include=$oViewConf->getPaymentGatewayUrl('out/js/wirecard_wdoxidee_sepadd.js') priority=9}]
 
+<style>
+  .wd-modal {
+    display: none;;
+  }
+</style>
+
 [{assign var="payment" value=$oView->getPayment()}]
 [{assign var="isConsentNeeded" value=$oView->isConsentNeeded()}]
 [{if $payment->oxpayments__oxid->value == "wdsepadd"}]
@@ -10,6 +16,7 @@
     </button>
     <div class="clearfix"></div>
   </div>
+  [{include file="sepa_mandate_modal.tpl"}]
 [{elseif $isConsentNeeded}]
   <form action="[{$oViewConf->getSslSelfLink()}]" method="post" id="orderConfirmAgbBottom" class="form-horizontal">
 
@@ -50,8 +57,6 @@
 [{else}]
   [{$smarty.block.parent}]
 [{/if}]
-
-[{include file="sepa_mandate_modal.tpl"}]
 
 [{if $isConsentNeeded}]
   <script>

--- a/views/blocks/order_button.tpl
+++ b/views/blocks/order_button.tpl
@@ -3,7 +3,7 @@
 
 <style>
   .wd-modal {
-    display: none;;
+    display: none;
   }
 </style>
 


### PR DESCRIPTION
### This PR

* Hides Sepa Direct Debit modal on initial order page load via inline style rule. This was normally done in wirecard_wdoxidee_modal.css, but in a certain situations it can happen that css was not loaded, and therefore modal was not hidden by default.

### How to Test

* Try to make a payment on frontend using Sepa Direct Debit and any other payment method. Sepa Direct Debit modal will not be loaded, until clicking on "Order Now" button in the case of Sepa Direct Debit payment method.

### Jira Links

* https://jira.parkside.at/browse/WDPD-240