### PR TITLE
WDPD-241 Get correct browser width for rendering credit card form

### DIFF
--- a/out/js/wirecard_wdoxidee_credit_card_form.js
+++ b/out/js/wirecard_wdoxidee_credit_card_form.js
@@ -16,9 +16,10 @@ var ModuleCreditCardForm = (function($) {
   }
 
   function callback() {
+    var browserWidth = window.innerWidth || document.body.clientWidth;
     $(".loader").fadeOut(200,function() {
       $("#creditcard-form-div")
-        .height(screen.width >= 992 ? 220 : 410)
+        .height(browserWidth >= 992 ? 220 : 410)
         .fadeIn(200);
       getOrderButton().prop("disabled", false);
     });


### PR DESCRIPTION
### This PR

* Gets browser width instead of screen width before selecting credit card form height.

### How to Test

* Try to make a purchase using Wirecard Credit Card payment method.
* On the last step of the checkout process, credit card form height should be 220px on desktop, and 410 on mobile screen, and it should not overlap with terms and condition under it.

### Jira Links

* https://jira.parkside.at/browse/WDPD-241