### PR TITLE
Fix top order button for credit card

### DIFF
--- a/out/js/wirecard_wdoxidee_credit_card_form.js
+++ b/out/js/wirecard_wdoxidee_credit_card_form.js
@@ -11,8 +11,8 @@ var ModuleCreditCardForm = (function($) {
 
   var requestData = null;
 
-  function getOrderButton() {
-    return $("#orderConfirmAgbBottom button[type = 'submit']");
+  function getOrderButtons() {
+    return $("#orderConfirmAgbTop, #orderConfirmAgbBottom").find("button[type = 'submit']");
   }
 
   function callback() {
@@ -21,7 +21,7 @@ var ModuleCreditCardForm = (function($) {
       $("#creditcard-form-div")
         .height(browserWidth >= 992 ? 220 : 410)
         .fadeIn(200);
-      getOrderButton().prop("disabled", false);
+      getOrderButtons().prop("disabled", false);
     });
 
     if (debug) {
@@ -120,9 +120,9 @@ var ModuleCreditCardForm = (function($) {
     init: function() {
       loadCCForm();
 
-      var orderButton = getOrderButton();
-      orderButton.prop("disabled", true);
-      orderButton.on("click", function(event) {
+      var orderButtons = getOrderButtons();
+      orderButtons.prop("disabled", true);
+      orderButtons.on("click", function(event) {
         event.preventDefault();
         submitPaymentForm(event);
       });


### PR DESCRIPTION
The top order button does not trigger `submitPaymentForm` and thus does not work correctly.  
This commit adds the necessary click handler to the button.